### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+<!-- Thank you so much for your contribution! -->
+## PR Checklist
+
+- [ ] Pull request points to the `dev` branch.
+- [ ] If it is a bugfix, the PR should have label `on-merge: backport-to-stable`.
+- [ ] For new code features, the PR should have been tested (please include the results of the tests below or, when possible, add a new test for the feature).


### PR DESCRIPTION
This adds a prefilled pull request template, including a checklist to help users point their PR towards the right branch (dev). See #19 for a discussion.