### PR TITLE
Fix `neul` definition in `mom2_mhd` patch

### DIFF
--- a/patch/mom2_mhd/cooling_fine.f90
+++ b/patch/mom2_mhd/cooling_fine.f90
@@ -100,11 +100,6 @@ subroutine coolfine1(ind_grid,ngrid,ilevel)
 #ifdef grackle
   real(kind=8),dimension(1:nvector),save:: T2_new
 #endif
-#ifdef SOLVERmhd
-  integer::neul=5
-#else
-  integer::neul=ndim+2
-#endif
 #if NENER>0
   integer::irad
 #endif

--- a/patch/mom2_mhd/courant_fine.f90
+++ b/patch/mom2_mhd/courant_fine.f90
@@ -187,7 +187,7 @@ subroutine velocity_fine(ilevel)
   ! the maximum density rho_max, and the potential energy
   !----------------------------------------------------------
   integer::igrid,ngrid,ncache,i,ind,iskip,ix,iy,iz
-  integer::nx_loc,idim,neul=5
+  integer::nx_loc,idim
   real(dp)::dx,dx_loc,scale,d,u,v,w,A,B,C
   real(dp),dimension(1:twotondim,1:3)::xc
   real(dp),dimension(1:3)::skip_loc

--- a/patch/mom2_mhd/godunov_fine.f90
+++ b/patch/mom2_mhd/godunov_fine.f90
@@ -762,7 +762,6 @@ subroutine godfine1(ind_grid,ncache,ilevel)
 
   integer,dimension(1:nvector),save::igrid_nbor,ind_cell,ind_buffer,ind_exist,ind_nexist
 
-  integer::neul=5
   integer::ind_buffer1,ind_buffer2,ind_buffer3
   integer::ind_father1,ind_father2,ind_father3
   integer::i,j,ivar,idim,ind_son,ind_father,iskip,nbuffer

--- a/patch/mom2_mhd/hydro_parameters.f90
+++ b/patch/mom2_mhd/hydro_parameters.f90
@@ -7,11 +7,18 @@ module hydro_parameters
 #else
   integer,parameter::nener=NENER
 #endif
+  integer,parameter::neul=5
+#ifndef NHYDRO
+  integer,parameter::nhydro=neul+3 !8
+#else
+  integer,parameter::nhydro=NHYDRO
+#endif
 #ifndef NVAR
-  integer,parameter::nvar=8+nener
+  integer,parameter::nvar=nhydro+nener
 #else
   integer,parameter::nvar=NVAR
 #endif
+  integer,parameter::nvar_all=nvar+3
 
   ! Size of hydro kernel
   integer,parameter::iu1=-1


### PR DESCRIPTION
<!-- Thank you so much for your contribution! -->

<!-- First describe what your PR is doing. -->
When attempting to compile an executable with the `mom2_mhd` patch, errors are thrown due to conflicting definitions of the `neul` variable.

This pull request removes these conflicting definitions from three source code files within the `patch/mom2_mhd` folder:
- `cooling_fine.f90`
- `courant_fine.f90`
- `godunov_fine.f90`

It also adds a global neul variable to `patch/mom2_mhd/hydro_parameters.f90`, and re-defines `nhydro`, `nvar`, and `nvar_all` accordingly.

<!-- Please check the following points -->
## PR Checklist

- [x] Pull request points to the `dev` branch
- [x] The pull request has a description
- [ ] If it is a bugfix that should be urgently merged to stable, the PR should have label `on-merge: backport-to-stable`.
- [ ] For new code features, the PR should have been tested (please include the results of the tests below or, when possible, add a new test for the feature).
- [ ] The code covered by the pull request is documented