### PR TITLE
[tests] Remove `pressure_fix` from barotrop and isothermal tests

### DIFF
--- a/tests/hydro/barotrop/barotrop.nml
+++ b/tests/hydro/barotrop/barotrop.nml
@@ -29,7 +29,7 @@ courant_factor=0.8
 scheme='muscl'
 slope_type=1
 riemann='hllc'
-pressure_fix=.true.
+pressure_fix=.false.
 beta_fix=0.5
 /
 

--- a/tests/hydro/isothermal/isothermal.nml
+++ b/tests/hydro/isothermal/isothermal.nml
@@ -28,7 +28,7 @@ courant_factor=0.8
 scheme='muscl'
 slope_type=1
 riemann='hllc'
-pressure_fix=.true.
+pressure_fix=.false.
 beta_fix=0.5
 /
 


### PR DESCRIPTION
Edited barotrop and isothermal tests : changed pressure_fix=.true. to .false.

