### PR TITLE
OpenMP: compile and launch test suite with threads

### DIFF
--- a/bin/Makefile
+++ b/bin/Makefile
@@ -108,7 +108,7 @@ ifeq ($(COMPILER),GNU)
    FC += -ffree-line-length-none -fimplicit-none
    ifeq ($(OPENMP),1)
       FFLAGS += -fopenmp
-      LIBS += -lgomp 	
+      LIBS += -lgomp
    endif
    ifeq ($(GCOV),1)
          F90 += -O0 -fprofile-arcs -ftest-coverage
@@ -138,8 +138,8 @@ ifeq ($(COMPILER),INTEL)
    FC += -fp-model source
    ifeq ($(OPENMP),1)
       FFLAGS += -fpp -qopenmp -DNOSYSTEM
-      LIBS += -liomp5 
-   endif	
+      LIBS += -liomp5
+   endif
    ifeq ($(DEBUG),1)
       F90 += -warn all -O0 -g -traceback -check bounds
       FFLAGS += -fpe0 -ftrapuv -init=zero -init=snan -init=arrays

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -26,6 +26,8 @@ USE_TURB = 0
 # Use MPI? 1=Yes, 0=No
 MPI = 0
 MPIF90 = mpif90
+# Use OpenMP? 1=Yes, 0=No
+OPENMP = 0
 # Root name of executable
 EXEC = ramses
 # Number of additional energies
@@ -85,9 +87,12 @@ endif
 ifeq ($(LIGHT_MPI_COMM), 1)
    DEFINES += -DLIGHT_MPI_COMM
 endif
+ifeq ($(OPENMP),1)
+   DEFINES += -DOPENMP
+endif
 #############################################################################
 # Fortran compiler options and directives
-
+LIBS =
 # GNU compiler (gfortran)
 ifeq ($(COMPILER),GNU)
    FFLAGS = -cpp $(DEFINES)
@@ -101,6 +106,10 @@ ifeq ($(COMPILER),GNU)
    endif
    F90 += -ffree-line-length-none -fimplicit-none
    FC += -ffree-line-length-none -fimplicit-none
+   ifeq ($(OPENMP),1)
+      FFLAGS += -fopenmp
+      LIBS += -lgomp 	
+   endif
    ifeq ($(GCOV),1)
          F90 += -O0 -fprofile-arcs -ftest-coverage
    else
@@ -127,6 +136,10 @@ ifeq ($(COMPILER),INTEL)
    endif
    F90 += -fp-model source
    FC += -fp-model source
+   ifeq ($(OPENMP),1)
+      FFLAGS += -fpp -qopenmp -DNOSYSTEM
+      LIBS += -liomp5 
+   endif	
    ifeq ($(DEBUG),1)
       F90 += -warn all -O0 -g -traceback -check bounds
       FFLAGS += -fpe0 -ftrapuv -init=zero -init=snan -init=arrays
@@ -154,7 +167,7 @@ ifeq ($(USE_TURB),1)
    LIBS_TURB = -L$(HOME)/local/lib -lfftw3
    LIBS_OBJ_TURB = -I$(HOME)/local/include -lfftw3
 endif
-LIBS = $(LIBMPI) $(LIBS_GRACKLE) $(LIBS_TURB)
+LIBS += $(LIBMPI) $(LIBS_GRACKLE) $(LIBS_TURB)
 #############################################################################
 # Sources directories are searched in this exact order
 VPATH = $(PATCH):../$(SOLVER):../aton:

--- a/tests/run_test_suite.sh
+++ b/tests/run_test_suite.sh
@@ -11,8 +11,12 @@
 #   ./run_test_suite.sh
 #
 # Options:
-#   - Run the suite in parallel (on 4 cpus):
+#   - Run the suite in parallel with MPI (on 4 cpus):
 #       ./run_test_suite.sh -p 4
+#   - Run the suite in parallel with OPENMP (on 4 cpus):
+#       ./run_test_suite.sh -m 4
+#   - Run the suite in parallel with MPI+OPENMP (on 4 cpus):
+#       ./run_test_suite.sh -p 2 -m 2
 #   - Do not delete results data:
 #       ./run_test_suite.sh -d
 #   - Run in verbose mode:
@@ -33,14 +37,16 @@ testlist="hydro,mhd,poisson,rt,sink,turb,tracer";
 # Determine the parameters for running the test suite
 #######################################################################
 MPI=0;
-NCPU=1;
 GCOV=0;
+OPENMP=0;
+NPROC=1;
+NTHREADS=1;
 VERBOSE=false;
 DELDATA=true;
 COVERAGE=false;
 CLEAN_ALL=false;
 SELECTTEST=false;
-while getopts "cdsp:qt:v" OPTION; do
+while getopts "cdsp:qm:t:v" OPTION; do
    case $OPTION in
       c)
          CLEAN_ALL=true;
@@ -54,7 +60,11 @@ while getopts "cdsp:qt:v" OPTION; do
       ;;
       p)
          MPI=1;
-         NCPU=$OPTARG;
+         NPROC=$OPTARG;
+      ;;
+      m)
+         OPENMP=1;
+         NTHREADS=$OPTARG;
       ;;
       t)
          SELECTTEST=true;
@@ -70,7 +80,7 @@ done
 # Setup paths and commands
 #######################################################################
 TEST_DIRECTORY=$(pwd);                    # The test suite directory
-BASE_DIRECTORY="${TEST_DIRECTORY}/.."; # The main RAMSES directory
+BASE_DIRECTORY="${TEST_DIRECTORY}/..";    # The main RAMSES directory
 BIN_DIRECTORY="${BASE_DIRECTORY}/bin";    # The bin directory
 VISU_DIR="${TEST_DIRECTORY}/visu";        # The visualization directory
 
@@ -83,8 +93,13 @@ GIT_URL=$(git config --get remote.origin.url | sed 's/git@github.com:/https:\/\/
 GIT_URL=${GIT_URL:0:$((${#GIT_URL}-4))};
 THIS_COMMIT=$(git rev-parse HEAD);
 echo > $LOGFILE;
+if [ ${OPENMP} -eq 1 ]; then
+   export OMP_NUM_THREADS=${NTHREADS}
+   export OMP_PLACES=cores
+   export OMP_PROC_BIND=true
+fi
 if [ ${MPI} -eq 1 ]; then
-   RUN_TEST_BASE="mpirun -np ${NCPU} ${BIN_DIRECTORY}/${EXECNAME}";
+   RUN_TEST_BASE="mpirun --map-by slot:pe=${NTHREADS} --np ${NPROC} ${BIN_DIRECTORY}/${EXECNAME}";
 else
    RUN_TEST_BASE="${BIN_DIRECTORY}/${EXECNAME}";
 fi
@@ -292,9 +307,9 @@ for ((i=0;i<$ntests;i++)); do
 
    # Compile source
    echo "Compiling source" | tee -a $LOGFILE;
-   MAKESTRING="make EXEC=${EXECNAME} MPI=${MPI} GCOV=${GCOV} ${FLAGS}";
+   MAKESTRING="make EXEC=${EXECNAME} MPI=${MPI} GCOV=${GCOV} ${FLAGS} OPENMP=${OPENMP}";
    # if [ ${MPI} -eq 1 ]; then
-   #    MAKESTRING="${MAKESTRING} -j ${NCPU}";
+   #    MAKESTRING="${MAKESTRING} -j ${NPROC}";
    # fi
    if $VERBOSE ; then
       $MAKESTRING 2>&1 | tee -a $LOGFILE;
@@ -412,7 +427,7 @@ echo "Commit hash: \href{${GIT_URL}/commits/${THIS_COMMIT}}{${THIS_COMMIT:0:6}}"
 echo "\end{center}" >> $latexfile;
 echo "\begin{table}[ht]" >> $latexfile;
 echo "\centering" >> $latexfile;
-echo "\caption*{Test run summary using ${NCPU} processor(s)}" >> $latexfile;
+echo "\caption*{Test run summary using ${NPROC} processes with ${NTHREADS} threads}" >> $latexfile;
 echo "\begin{tabular}{|r|l|l|l|l|}" >> $latexfile;
 echo "\hline" >> $latexfile;
 echo "~ & Test name & Run time & Total time & Status\\\\" >> $latexfile;


### PR DESCRIPTION
Modify makefile to be able to compile with openMP.
Modify test suite to be able to lauch with openMP threads in addition to MPI processes by setting the command parameter -m.