### PR TITLE
Increase available characters for number of particles in output header

### DIFF
--- a/amr/output_amr.f90
+++ b/amr/output_amr.f90
@@ -547,12 +547,12 @@ subroutine output_header(filename)
 #endif
 
   if (myid == 1) then
-     write(ilun, '(a1,a12,a10)') '#', 'Family', 'Count'
+     write(ilun, '(a1,a12,a15)') '#', 'Family', 'Count'
      do ifam = -NFAMILIES, NFAMILIES
-        write(ilun, '(a13, i10)') &
+        write(ilun, '(a13, i15)') &
              trim(particle_family_keys(ifam)), npart_family(ifam)
      end do
-     write(ilun, '(a13, i10)') &
+     write(ilun, '(a13, i15)') &
           'undefined', npart_all - sum(npart_family)
   end if
 


### PR DESCRIPTION
Prevent particle family name from sticking to particle count in the header file for 1024^3 particles. This made my post-processing tool scream. Let's be more ambitious!

![Screenshot from 2025-03-28 17-20-22](https://github.com/user-attachments/assets/d05b79b8-4bb1-462d-9a7e-9f2bbfb6331f)
