### PR TITLE
Code cleaning in rho fine and poisson/

### DIFF
--- a/pm/rho_fine.f90
+++ b/pm/rho_fine.f90
@@ -203,14 +203,6 @@ subroutine rho_fine(ilevel,icount)
      call make_virtual_fine_int(cpu_map2(1),ilevel)
   end if
 
-!!$  do ind=1,twotondim
-!!$     iskip=ncoarse+(ind-1)*ngridmax
-!!$     do i=1,active(ilevel)%ngrid
-!!$        print*,rho(active(ilevel)%igrid(i)+iskip),rho_tot
-!!$     end do
-!!$  end do
-
-
 111 format('   Entering rho_fine for level ',I2)
 
 end subroutine rho_fine
@@ -381,15 +373,7 @@ subroutine cic_amr(ind_cell,ind_part,ind_grid_part,x0,ng,np,ilevel)
   do idim=1,ndim
      do j=1,np
         x(j,idim)=xp(ind_part(j),idim)/scale+skip_loc(idim)
-     end do
-  end do
-  do idim=1,ndim
-     do j=1,np
         x(j,idim)=x(j,idim)-x0(ind_grid_part(j),idim)
-     end do
-  end do
-  do idim=1,ndim
-     do j=1,np
         x(j,idim)=x(j,idim)/dx
      end do
   end do
@@ -562,9 +546,6 @@ subroutine cic_amr(ind_cell,ind_part,ind_grid_part,x0,ng,np,ilevel)
 
      do j=1,np
         ok(j)=(igrid(j,ind)>0).and.is_not_tracer(fam(j))
-     end do
-
-     do j=1,np
         vol2(j)=mmm(j)*vol(j,ind)/vol_loc
      end do
 
@@ -958,15 +939,7 @@ subroutine cic_cell(ind_grid,ngrid,ilevel)
      do idim=1,ndim
         do j=1,np
            x(j,idim)=x(j,idim)/scale+skip_loc(idim)
-        end do
-     end do
-     do idim=1,ndim
-        do j=1,np
            x(j,idim)=x(j,idim)-(xg(ind_grid(j),idim)-3d0*dx)
-        end do
-     end do
-     do idim=1,ndim
-        do j=1,np
            x(j,idim)=x(j,idim)/dx
         end do
      end do
@@ -1119,8 +1092,6 @@ subroutine cic_cell(ind_grid,ngrid,ilevel)
      do ind=1,twotondim
         do j=1,np
            ok(j)=igrid(j,ind)>0
-        end do
-        do j=1,np
            vol2(j)=mmm(j)*vol(j,ind)/vol_loc
         end do
         do j=1,np
@@ -1189,15 +1160,7 @@ subroutine tsc_amr(ind_cell,ind_part,ind_grid_part,x0,ng,np,ilevel)
   do idim=1,ndim
      do j=1,np
         x(j,idim)=xp(ind_part(j),idim)/scale+skip_loc(idim)
-     end do
-  end do
-  do idim=1,ndim
-     do j=1,np
         x(j,idim)=x(j,idim)-x0(ind_grid_part(j),idim)
-     end do
-  end do
-  do idim=1,ndim
-     do j=1,np
         x(j,idim)=x(j,idim)/dx
      end do
   end do
@@ -1389,11 +1352,6 @@ subroutine tsc_amr(ind_cell,ind_part,ind_grid_part,x0,ng,np,ilevel)
      do j=1,np
         if(.not.abandoned(j)) then
            ok(j)=igrid(j,ind)>0
-        end if
-     end do
-
-     do j=1,np
-        if(.not.abandoned(j)) then
            vol2(j)=mmm(j)*vol(j,ind)/vol_loc
         end if
      end do
@@ -1546,15 +1504,7 @@ subroutine tsc_cell(ind_grid,ngrid,ilevel)
      do idim=1,ndim
         do j=1,np
            x(j,idim)=x(j,idim)/scale+skip_loc(idim)
-        end do
-     end do
-     do idim=1,ndim
-        do j=1,np
            x(j,idim)=x(j,idim)-(xg(ind_grid(j),idim)-3d0*dx)
-        end do
-     end do
-     do idim=1,ndim
-        do j=1,np
            x(j,idim)=x(j,idim)/dx
         end do
      end do
@@ -1726,8 +1676,6 @@ subroutine tsc_cell(ind_grid,ngrid,ilevel)
      do ind=1,threetondim
         do j=1,np
            ok(j)=igrid(j,ind)>0
-        end do
-        do j=1,np
            vol2(j)=mmm(j)*vol(j,ind)/vol_loc
         end do
         do j=1,np

--- a/pm/rho_fine.f90
+++ b/pm/rho_fine.f90
@@ -26,7 +26,7 @@ subroutine rho_fine(ilevel,icount)
   ! - cpu_map2 containing the refinement map due to particle
   !   number density criterion (quasi Lagrangian mesh).
   !------------------------------------------------------------------
-  integer::iskip,icpu,ind,i,nx_loc,ibound
+  integer::iskip,icpu,ind,i,nx_loc,ibound,ind_cell
   real(dp)::dx,d_scale,scale,dx_loc,scalar
 
   if(.not. poisson)return
@@ -73,9 +73,9 @@ subroutine rho_fine(ilevel,icount)
      do ind=1,twotondim
         iskip=ncoarse+(ind-1)*ngridmax
         do i=1,active(ilevel)%ngrid
-           rho_top(active(ilevel)%igrid(i)+iskip)=rho_top(father(active(ilevel)%igrid(i)))
-           rho(active(ilevel)%igrid(i)+iskip)=rho(active(ilevel)%igrid(i)+iskip)+ &
-                & rho_top(active(ilevel)%igrid(i)+iskip)
+           ind_cell=active(ilevel)%igrid(i)+iskip
+           rho_top(ind_cell)=rho_top(father(active(ilevel)%igrid(i)))
+           rho(ind_cell)=rho(ind_cell)+rho_top(ind_cell)
         end do
      end do
   endif
@@ -90,17 +90,16 @@ subroutine rho_fine(ilevel,icount)
         if(hydro)then
            if(ivar_refine>0)then
               do i=1,active(ilevel)%ngrid
-                 scalar=uold(active(ilevel)%igrid(i)+iskip,ivar_refine) &
-                      & /max(uold(active(ilevel)%igrid(i)+iskip,1),smallr)
+                 ind_cell=active(ilevel)%igrid(i)+iskip
+                 scalar=uold(ind_cell,ivar_refine)/max(uold(ind_cell,1),smallr)
                  if(scalar>var_cut_refine)then
-                    phi(active(ilevel)%igrid(i)+iskip)= &
-                         & rho(active(ilevel)%igrid(i)+iskip)/d_scale
+                    phi(ind_cell)=rho(ind_cell)/d_scale
                  endif
               end do
            else
               do i=1,active(ilevel)%ngrid
-                 phi(active(ilevel)%igrid(i)+iskip)= &
-                      & rho(active(ilevel)%igrid(i)+iskip)/d_scale
+                 ind_cell=active(ilevel)%igrid(i)+iskip
+                 phi(ind_cell)=rho(ind_cell)/d_scale
               end do
            endif
         endif
@@ -192,10 +191,11 @@ subroutine rho_fine(ilevel,icount)
      do ind=1,twotondim
         iskip=ncoarse+(ind-1)*ngridmax
         do i=1,active(ilevel)%ngrid
-           if(phi(active(ilevel)%igrid(i)+iskip)>=m_refine(ilevel))then
-              cpu_map2(active(ilevel)%igrid(i)+iskip)=1
+           ind_cell=active(ilevel)%igrid(i)+iskip
+           if(phi(ind_cell)>=m_refine(ilevel))then
+              cpu_map2(ind_cell)=1
            else
-              cpu_map2(active(ilevel)%igrid(i)+iskip)=0
+              cpu_map2(ind_cell)=0
            end if
         end do
      end do

--- a/poisson/boundary_potential.f90
+++ b/poisson/boundary_potential.f90
@@ -64,11 +64,9 @@ subroutine make_boundary_force(ilevel)
      do igrid=1,ncache,nvector
         ngrid=MIN(nvector,ncache-igrid+1)
         do i=1,ngrid
+           ! Gather nvector grids
            ind_grid(i)=boundary(ibound,ilevel)%igrid(igrid+i-1)
-        end do
-
-        ! Gather neighboring reference grid
-        do i=1,ngrid
+           ! Gather neighboring reference grid
            ind_grid_ref(i)=son(nbor(ind_grid(i),inbor))
         end do
 

--- a/poisson/force_fine.f90
+++ b/poisson/force_fine.f90
@@ -73,17 +73,13 @@ subroutine force_fine(ilevel,icount)
            do i=1,ngrid
               ind_cell(i)=iskip+ind_grid(i)
            end do
-           ! Gather cell centre positions
+           ! Gather cell centre positions and
+           ! rescale position from code units to user units
            do idim=1,ndim
               do i=1,ngrid
                  xx(i,idim)=xg(ind_grid(i),idim)+xc(ind,idim)
-              end do
-           end do
-           ! Rescale position from code units to user units
-           do idim=1,ndim
-              do i=1,ngrid
                  xx(i,idim)=(xx(i,idim)-skip_loc(idim))*scale
-              end do
+               end do
            end do
 
            ! Call analytical gravity routine
@@ -292,29 +288,21 @@ subroutine gradient_phi(ind_grid,ngrid,ilevel,icount)
            else
               phi1(i)=phi_left(i,id1,idim)
            end if
-        end do
-        do i=1,ngrid
            if(igridn(i,ig2)>0)then
               phi2(i)=phi(igridn(i,ig2)+ih2)
            else
               phi2(i)=phi_right(i,id2,idim)
            end if
-        end do
-        do i=1,ngrid
            if(igridn(i,ig3)>0)then
               phi3(i)=phi(igridn(i,ig3)+ih3)
            else
               phi3(i)=phi_left(i,id3,idim)
            end if
-        end do
-        do i=1,ngrid
            if(igridn(i,ig4)>0)then
               phi4(i)=phi(igridn(i,ig4)+ih4)
            else
               phi4(i)=phi_right(i,id4,idim)
            end if
-        end do
-        do i=1,ngrid
            f(ind_cell(i),idim)=a*(phi1(i)-phi2(i)) &
                 &             -b*(phi3(i)-phi4(i))
         end do

--- a/poisson/gravana.f90
+++ b/poisson/gravana.f90
@@ -107,19 +107,13 @@ subroutine phi_ana(rr,pp,ngrid)
 
   fourpi=2*twopi
 
+  do i=1,ngrid
 #if NDIM==1
-  do i=1,ngrid
      pp(i)=multipole(1)*fourpi/2*rr(i)
-  end do
-#endif
-#if NDIM==2
-  do i=1,ngrid
+#elif NDIM==2
      pp(i)=multipole(1)*2*log(rr(i))
-  end do
-#endif
-#if NDIM==3
-  do i=1,ngrid
+#elif NDIM==3
      pp(i)=-multipole(1)/rr(i)
-  end do
 #endif
+  end do
 end subroutine phi_ana

--- a/poisson/multigrid_fine_fine.f90
+++ b/poisson/multigrid_fine_fine.f90
@@ -62,7 +62,7 @@ subroutine restrict_mask_fine_reverse(ifinelevel)
          icell_c_mg=iskip_c_mg+igrid_c_mg
 
          ! Stack cell volume fraction in coarse cell
-         ngpmask=(1d0+f(icell_f_amr,3))/2/dtwotondim
+         ngpmask=(1d0+f(icell_f_amr,3))/2d0/dtwotondim
 #ifdef LIGHT_MPI_COMM
          active_mg(cpu_amr,icoarselevel)%pcomm%u(icell_c_mg,4)=&
             active_mg(cpu_amr,icoarselevel)%pcomm%u(icell_c_mg,4)+ngpmask

--- a/poisson/phi_fine_cg.f90
+++ b/poisson/phi_fine_cg.f90
@@ -36,7 +36,6 @@ subroutine phi_fine_cg(ilevel,icount)
   if(numbtot(1,ilevel)==0)return
   if(verbose)write(*,111)ilevel
 
-
   ! Set constants
   dx2=(0.5D0**ilevel)**2
   nx_loc=icoarse_max-icoarse_min+1
@@ -162,23 +161,13 @@ subroutine phi_fine_cg(ilevel,icount)
      alpha_cg = r2/pAp
 
      !====================================
-     ! Recurrence on x
+     ! Recurrence on x and r
      !====================================
      do ind=1,twotondim
         iskip=ncoarse+(ind-1)*ngridmax
         do i=1,active(ilevel)%ngrid
            idx=active(ilevel)%igrid(i)+iskip
            phi(idx)=phi(idx)+alpha_cg*f(idx,2)
-        end do
-     end do
-
-     !====================================
-     ! Recurrence on r
-     !====================================
-     do ind=1,twotondim
-        iskip=ncoarse+(ind-1)*ngridmax
-        do i=1,active(ilevel)%ngrid
-           idx=active(ilevel)%igrid(i)+iskip
            f(idx,1)=f(idx,1)-alpha_cg*f(idx,3)
         end do
      end do
@@ -221,8 +210,8 @@ subroutine cmp_residual_cg(ilevel,icount)
   ! This routine computes the residual for the Conjugate Gradient
   ! Poisson solver. The residual is stored in f(i,1).
   !------------------------------------------------------------------
-  integer::i,idim,igrid,ngrid,ncache,ind,iskip,nx_loc
-  integer::id1,id2,ig1,ig2,ih1,ih2
+  integer::i,idim,inbor,igrid,ngrid,ncache,ind,iskip,nx_loc
+  integer::id1,ig1,ih1
   real(dp)::dx2,fourpi,scale,oneoversix,fact
 
   integer ,dimension(1:nvector),save::ind_grid,ind_cell
@@ -274,7 +263,9 @@ subroutine cmp_residual_cg(ilevel,icount)
      do ind=1,twotondim
         ! Gather neighboring potential
         do idim=1,ndim
-           id1=jjj(idim,1,ind); ig1=iii(idim,1,ind)
+        do inbor=1,2
+           id1=jjj(idim,inbor,ind)
+           ig1=iii(idim,inbor,ind)
            ih1=ncoarse+(id1-1)*ngridmax
            do i=1,ngrid
               if(igridn(i,ig1)>0)then
@@ -283,15 +274,7 @@ subroutine cmp_residual_cg(ilevel,icount)
                  phig(i,idim)=phi_left(i,id1,idim)
               end if
            end do
-           id2=jjj(idim,2,ind); ig2=iii(idim,2,ind)
-           ih2=ncoarse+(id2-1)*ngridmax
-           do i=1,ngrid
-              if(igridn(i,ig2)>0)then
-                 phid(i,idim)=phi(igridn(i,ig2)+ih2)
-              else
-                 phid(i,idim)=phi_right(i,id2,idim)
-              end if
-           end do
+        end do
         end do
 
         ! Compute central cell index
@@ -313,15 +296,11 @@ subroutine cmp_residual_cg(ilevel,icount)
            residu(i)=residu(i)+fact*(rho(ind_cell(i))-rho_tot)
         end do
 
-        ! Store results in f(i,1)
+        ! Store results in f(i,1) and f(i,2)
         do i=1,ngrid
            f(ind_cell(i),1)=residu(i)
-        end do
-
-        ! Store results in f(i,2)
-        do i=1,ngrid
            f(ind_cell(i),2)=residu(i)
-        end do
+         end do
 
      end do
      ! End loop over cells
@@ -346,8 +325,8 @@ subroutine cmp_Ap_cg(ilevel)
   ! This routine computes Ap for the Conjugate Gradient
   ! Poisson Solver and store the result into f(i,3).
   !------------------------------------------------------------------
-  integer::i,idim,igrid,ngrid,ncache,ind,iskip
-  integer::id1,id2,ig1,ig2,ih1,ih2
+  integer::i,idim,inbor,igrid,ngrid,ncache,ind,iskip
+  integer::id1,ig1,ih1
   real(dp)::oneoversix
 
   integer,dimension(1:nvector),save::ind_grid,ind_cell
@@ -384,7 +363,9 @@ subroutine cmp_Ap_cg(ilevel)
 
         ! Gather neighboring potential
         do idim=1,ndim
-           id1=jjj(idim,1,ind); ig1=iii(idim,1,ind)
+        do inbor=1,2
+           id1=jjj(idim,inbor,ind)
+           ig1=iii(idim,inbor,ind)
            ih1=ncoarse+(id1-1)*ngridmax
            do i=1,ngrid
               if(igridn(i,ig1)>0)then
@@ -393,15 +374,7 @@ subroutine cmp_Ap_cg(ilevel)
                  phig(i,idim)=0
               end if
            end do
-           id2=jjj(idim,2,ind); ig2=iii(idim,2,ind)
-           ih2=ncoarse+(id2-1)*ngridmax
-           do i=1,ngrid
-              if(igridn(i,ig2)>0)then
-                 phid(i,idim)=f(igridn(i,ig2)+ih2,2)
-              else
-                 phid(i,idim)=0
-              end if
-           end do
+        end do
         end do
 
         ! Compute central cell index
@@ -463,8 +436,6 @@ subroutine make_initial_phi(ilevel,icount)
            iskip=ncoarse+(ind-1)*ngridmax
            do i=1,ngrid
               ind_cell(i)=iskip+ind_grid(i)
-           end do
-           do i=1,ngrid
               phi(ind_cell(i))=0
            end do
            do idim=1,ndim
@@ -488,8 +459,6 @@ subroutine make_initial_phi(ilevel,icount)
            iskip=ncoarse+(ind-1)*ngridmax
            do i=1,ngrid
               ind_cell(i)=iskip+ind_grid(i)
-           end do
-           do i=1,ngrid
               phi(ind_cell(i))=phi_int(i,ind)
            end do
            do idim=1,ndim
@@ -525,7 +494,7 @@ subroutine make_multipole_phi(ilevel)
   real(dp),dimension(1:3)::skip_loc
   real(dp),dimension(1:twotondim,1:3)::xc
   real(dp),dimension(1:nvector),save::rr,pp
-  real(dp),dimension(1:nvector,1:ndim),save::xx
+  real(dp),dimension(1:nvector),save::xx
 
   ! Mesh size at level ilevel
   dx=0.5D0**ilevel
@@ -568,19 +537,14 @@ subroutine make_multipole_phi(ilevel)
         end do
 
         if(simple_boundary)then
-           ! Compute cell center in code units
-           do idim=1,ndim
-               do i=1,ngrid
-                  xx(i,idim)=xg(ind_grid(i),idim)+xc(ind,idim)
-               end do
-           end do
-
-           ! Rescale position from code units to user units
            rr(1:ngrid)=0.0d0
            do idim=1,ndim
                do i=1,ngrid
-                  xx(i,idim)=(xx(i,idim)-skip_loc(idim))*scale
-                  rr(i)=rr(i)+(xx(i,idim)-multipole(idim+1)/multipole(1))**2
+                  ! Compute cell center in code units
+                  xx(i)=xg(ind_grid(i),idim)+xc(ind,idim)
+                  ! Rescale position from code units to user units
+                  xx(i)=(xx(i)-skip_loc(idim))*scale
+                  rr(i)=rr(i)+(xx(i)-multipole(idim+1)/multipole(1))**2
                end do
            end do
 


### PR DESCRIPTION
* Remove duplicate loop structures where the instructions can be executed in the same loop.
* in rho_fine, Calculate the cell index before using it to access multiple arrays, instead of recalculating it.

These changes make the code more readable.
I measured no impact on performance.