### PR TITLE
More consistent variable speed of light without RT subcycling.

### DIFF
--- a/amr/refine_utils.f90
+++ b/amr/refine_utils.f90
@@ -874,17 +874,9 @@ subroutine make_grid_fine(ind_grid,ind_cell,ind,ilevel,nn,ibound,boundary_region
               do i=1,nn
                  rtuold(iskip+ind_grid_son(i),ivar)=urt2(i,j,ivar)
                  ! Rescale according to different speeds of light
-                 if(rt_nsubcycle.eq.1) then
-                    ! Without RT subcycling, we conserve the number of photons
-                    if (ivar.le. nrtvar .and. mod(ivar,ndim+1).ne.1) &
-                        rtuold(iskip+ind_grid_son(i),ivar) = &
-                          rtuold(iskip+ind_grid_son(i),ivar) * rt_c(ilevel)/rt_c(ilevel-1)
-                 else
-                    ! RT subcycling: photons not convserved -> prevent level boundary problems
-                    if (ivar.le. nrtvar .and. mod(ivar,ndim+1).eq.1) &
-                        rtuold(iskip+ind_grid_son(i),ivar) = &
-                          rtuold(iskip+ind_grid_son(i),ivar) * rt_c(ilevel-1)/rt_c(ilevel)
-                 endif
+                 if (ivar.le. nrtvar .and. mod(ivar,ndim+1).eq.1) &
+                    rtuold(iskip+ind_grid_son(i),ivar) = &
+                      rtuold(iskip+ind_grid_son(i),ivar) * rt_c(ilevel-1)/rt_c(ilevel)
               end do
            end do
         enddo
@@ -981,13 +973,8 @@ subroutine kill_grid(ind_cell,ilevel,nn,ibound,boundary_region)
   do ivar=1,nrtvar
      do i=1,nn
         ! Rescale according to speed of light difference
-        if(rt_nsubcycle.eq.1) then
-           if (ivar.le. nrtvar .and. mod(ivar,ndim+1).ne.1) &
-             rtuold(ind_cell(i),ivar) = rtuold(ind_cell(i),ivar) * rt_c(ilevel-1)/rt_c(ilevel)
-        else
-           if (ivar.le. nrtvar .and. mod(ivar,ndim+1).eq.1) &
-             rtuold(ind_cell(i),ivar) = rtuold(ind_cell(i),ivar) * rt_c(ilevel)/rt_c(ilevel-1)
-        endif
+        if (ilevel .gt. levelmin .and. ivar.le. nrtvar .and. mod(ivar,ndim+1).eq.1) &
+            rtuold(ind_cell(i),ivar) = rtuold(ind_cell(i),ivar) * rt_c(ilevel)/rt_c(ilevel-1)
      end do
   end do
 #endif


### PR DESCRIPTION
More consistent variable speed of light without RT subcycling.
Plus fix of division-by-zero crash at the initialization of cosmological simulations (in debug mode).

<!-- Thank you so much for your contribution! -->

<!-- First describe what your PR is doing.

> [!WARNING]
>  Please uncomment this to tell everyone if there is a breacking change.
 -->

<!-- Please check the following points -->
## PR Checklist

- [x] Pull request points to the `dev` branch
- [x] The pull request has a description
- [ ] If it is a bugfix that should be urgently merged to stable, the PR should have label `on-merge: backport-to-stable`.
- [ ] For new code features, the PR should have been tested (please include the results of the tests below or, when possible, add a new test for the feature).
- [ ] The code covered by the pull request is documented
