### PR TITLE
Use the communicator active instead of the linked list

### DIFF
--- a/pm/move_fine.f90
+++ b/pm/move_fine.f90
@@ -19,8 +19,8 @@ subroutine move_fine(ilevel)
   ig=0
   ip=0
   ! Loop over particles that are not tracers
-  igrid=headl(myid,ilevel)
-  do jgrid=1,numbl(myid,ilevel)
+  do jgrid=1,active(ilevel)%ngrid
+     igrid=active(ilevel)%igrid(jgrid)
      npart1=numbp(igrid)  ! Number of particles in the grid
      if(npart1>0)then
         ig=ig+1
@@ -58,7 +58,6 @@ subroutine move_fine(ilevel)
            ig=ig-1
         end if
      end if
-     igrid=next(igrid)   ! Go to next grid
   end do
   ! End loop over grids
   if(ip>0)call move1(ind_grid,ind_part,ind_grid_part,ig,ip,ilevel)
@@ -98,8 +97,8 @@ subroutine move_fine_static(ilevel)
   ig=0
   ip=0
   ! Loop over grids
-  igrid=headl(myid,ilevel)
-  do jgrid=1,numbl(myid,ilevel)
+  do jgrid=1,active(ilevel)%ngrid
+     igrid=active(ilevel)%igrid(jgrid)
      npart1=numbp(igrid)  ! Number of particles in the grid
      npart2=0
 
@@ -178,7 +177,6 @@ subroutine move_fine_static(ilevel)
         end if
         ! End loop over particles
      end if
-     igrid=next(igrid)   ! Go to next grid
   end do
   ! End loop over grids
   if(ip>0)call move1(ind_grid,ind_part,ind_grid_part,ig,ip,ilevel)

--- a/pm/move_tracer.f90
+++ b/pm/move_tracer.f90
@@ -1,5 +1,5 @@
 subroutine move_tracer_fine(ilevel)
-   use amr_commons, only: headl, numbl, next, nvector, myid
+   use amr_commons, only: headl, numbl, next, nvector, myid, active
    use pm_commons, only: typep, headp, numbp, nextp, move_flag
    use pm_commons, only: is_gas_tracer, is_star_tracer, is_cloud_tracer, part_t
    implicit none
@@ -15,8 +15,8 @@ subroutine move_tracer_fine(ilevel)
    ind_part=0
    ind_grid_part=0
 
-   igrid=headl(myid,ilevel)
-   do jgrid=1,numbl(myid,ilevel)
+   do jgrid=1,active(ilevel)%ngrid
+      igrid=active(ilevel)%igrid(jgrid)
       npart1=numbp(igrid)  ! Number of particles in the grid
       if(npart1>0)then
          ig=ig+1
@@ -57,7 +57,6 @@ subroutine move_tracer_fine(ilevel)
             ig=ig-1
          end if
       end if
-      igrid=next(igrid)   ! Go to next grid
    end do
    ! End loop over grids
    if(ip>0) call move_gas_tracer(ind_grid,ind_part,ind_grid_part,ig,ip,ilevel) ! MC Tracer

--- a/pm/newdt_fine.f90
+++ b/pm/newdt_fine.f90
@@ -123,8 +123,8 @@ subroutine newdt_fine(ilevel)
      if(numbl(myid,ilevel)>0)then
         ! Loop over grids
         ip=0
-        igrid=headl(myid,ilevel)
-        do jgrid=1,numbl(myid,ilevel)
+        do jgrid=1,active(ilevel)%ngrid
+           igrid=active(ilevel)%igrid(jgrid)
            npart1=numbp(igrid)   ! Number of particles in the grid
            if(npart1>0)then
               ! Loop over particles
@@ -151,7 +151,6 @@ subroutine newdt_fine(ilevel)
               end do
               ! End loop over particles
            end if
-           igrid=next(igrid)   ! Go to next grid
         end do
         ! End loop over grids
         if(ip>0)call newdt2(ind_part,dt_loc,ekin_loc,ip,ilevel)

--- a/pm/sink_particle.f90
+++ b/pm/sink_particle.f90
@@ -2019,8 +2019,8 @@ subroutine update_cloud(ilevel)
   ig=0
   ip=0
   ! Loop over grids
-  igrid=headl(myid,ilevel)
-  do jgrid=1,numbl(myid,ilevel)
+  do jgrid=1,active(ilevel)%ngrid
+     igrid=active(ilevel)%igrid(jgrid)
      npart1=numbp(igrid)  ! Number of particles in the grid
      if(npart1>0)then
         ig=ig+1
@@ -2046,7 +2046,6 @@ subroutine update_cloud(ilevel)
         end do
         ! End loop over particles
      end if
-     igrid=next(igrid)   ! Go to next grid
   end do
   ! End loop over grids
   if(ip>0)call upd_cloud(ind_part,ip)

--- a/pm/synchro_fine.f90
+++ b/pm/synchro_fine.f90
@@ -28,8 +28,8 @@ subroutine synchro_fine(ilevel)
   ig=0
   ip=0
   ! Loop over grids
-  igrid=headl(myid,ilevel)
-  do jgrid=1,numbl(myid,ilevel)
+  do jgrid=1,active(ilevel)%ngrid
+     igrid=active(ilevel)%igrid(jgrid)
      npart1=numbp(igrid)  ! Number of particles in the grid
      if(npart1>0)then
         ig=ig+1
@@ -66,7 +66,6 @@ subroutine synchro_fine(ilevel)
            ig=ig-1
         end if
      end if
-     igrid=next(igrid)   ! Go to next grid
   end do
   ! End loop over grids
   if(ip>0)call sync(ind_grid,ind_part,ind_grid_part,ig,ip,ilevel)
@@ -125,8 +124,8 @@ subroutine synchro_fine_static(ilevel)
   ig=0
   ip=0
   ! Loop over grids
-  igrid=headl(myid,ilevel)
-  do jgrid=1,numbl(myid,ilevel)
+  do jgrid=1,active(ilevel)%ngrid
+     igrid=active(ilevel)%igrid(jgrid)
      npart1=numbp(igrid)  ! Number of particles in the grid
      npart2=0
 
@@ -194,7 +193,6 @@ subroutine synchro_fine_static(ilevel)
         end do
         ! End loop over particles
      end if
-     igrid=next(igrid)   ! Go to next grid
   end do
   ! End loop over grids
   if(ip>0)call sync(ind_grid,ind_part,ind_grid_part,ig,ip,ilevel)


### PR DESCRIPTION
Loop over the elements of the communicator active instead of following the linked list for loops over grids in the current cpu. This change is needed to prepare for the openMP implementation.

Affected subroutines:
- move_fine
- move_fine_static
- synchro_fine
- synchro_fine_static
- move_tracer_fine
- newdt_fine
- update_cloud
