### PR TITLE
[SPACE] Optimize and document nbor utils

### DIFF
--- a/amr/amr_commons.f90
+++ b/amr/amr_commons.f90
@@ -70,7 +70,7 @@ module amr_commons
   integer ,allocatable,dimension(:)  ::father  ! father cell
   integer ,allocatable,dimension(:)  ::next    ! next grid in list
   integer ,allocatable,dimension(:)  ::prev    ! previous grid in list
-  integer ,allocatable,dimension(:)  ::son     ! sons grids
+  integer ,allocatable,dimension(:)  ::son     ! sons grid
   integer ,allocatable,dimension(:)  ::flag1   ! flag for refine
   integer ,allocatable,dimension(:)  ::flag2   ! flag for expansion
 

--- a/amr/amr_constants.f90
+++ b/amr/amr_constants.f90
@@ -20,33 +20,33 @@ module amr_constants
                                        /), shape=(/3,2,8/), order=(/3,2,1/))
 
 #if NDIM==1
-  integer,dimension(1:twotondim,1:threetondim),parameter::lll=reshape( (/ &
+  integer,dimension(1:threetondim,1:twotondim),parameter::lll=reshape( (/ &
                                                                    2,1,1, &  !ind=1
                                                                    1,1,2  &  !ind=2
-                                 /), shape=(/twotondim,threetondim/), order=(/2,1/))
+                                               /), shape=(/threetondim,twotondim/))
 
-  integer,dimension(1:twotondim,1:threetondim),parameter::mmm=reshape( (/ &
+  integer,dimension(1:threetondim,1:twotondim),parameter::mmm=reshape( (/ &
                                                                    2,1,2, &  !ind=1
                                                                    1,2,1  &  !ind=2
-                                 /), shape=(/twotondim,threetondim/), order=(/2,1/))
+                                               /), shape=(/threetondim,twotondim/))
 
 #elif NDIM==2
-  integer,dimension(1:twotondim,1:threetondim),parameter::lll=reshape( (/ &
+  integer,dimension(1:threetondim,1:twotondim),parameter::lll=reshape( (/ &
                                                        4,3,3,2,1,1,2,1,1, &  !ind=1
                                                        3,3,4,1,1,2,1,1,2, &  !ind=2
                                                        2,1,1,2,1,1,4,3,3, &  !ind=3
                                                        1,1,2,1,1,2,3,3,4  &  !ind=4
-                                 /), shape=(/twotondim,threetondim/), order=(/2,1/))
+                                               /), shape=(/threetondim,twotondim/))
 
-  integer,dimension(1:twotondim,1:threetondim),parameter::mmm=reshape( (/ &
+  integer,dimension(1:threetondim,1:twotondim),parameter::mmm=reshape( (/ &
                                                        4,3,4,2,1,2,4,3,4, &  !ind=1
                                                        3,4,3,1,2,1,3,4,3, &  !ind=2
                                                        2,1,2,4,3,4,2,1,2, &  !ind=3
                                                        1,2,1,3,4,3,1,2,1  &  !ind=4
-                                 /), shape=(/twotondim,threetondim/), order=(/2,1/))
+                                               /), shape=(/threetondim,twotondim/))
 
 #elif NDIM==3
-  integer,dimension(1:twotondim,1:threetondim),parameter::lll=reshape( (/ &
+  integer,dimension(1:threetondim,1:twotondim),parameter::lll=reshape( (/ &
                    8,7,7,6,5,5,6,5,5,4,3,3,2,1,1,2,1,1,4,3,3,2,1,1,2,1,1, &  !ind=1
                    7,7,8,5,5,6,5,5,6,3,3,4,1,1,2,1,1,2,3,3,4,1,1,2,1,1,2, &  !ind=2
                    6,5,5,6,5,5,8,7,7,2,1,1,2,1,1,4,3,3,2,1,1,2,1,1,4,3,3, &  !ind=3
@@ -55,9 +55,9 @@ module amr_constants
                    3,3,4,1,1,2,1,1,2,3,3,4,1,1,2,1,1,2,7,7,8,5,5,6,5,5,6, &  !ind=6
                    2,1,1,2,1,1,4,3,3,2,1,1,2,1,1,4,3,3,6,5,5,6,5,5,8,7,7, &  !ind=7
                    1,1,2,1,1,2,3,3,4,1,1,2,1,1,2,3,3,4,5,5,6,5,5,6,7,7,8  &  !ind=8
-                                 /), shape=(/twotondim,threetondim/), order=(/2,1/))
+                                               /), shape=(/threetondim,twotondim/))
 
-  integer,dimension(1:twotondim,1:threetondim),parameter::mmm=reshape( (/ &
+  integer,dimension(1:threetondim,1:twotondim),parameter::mmm=reshape( (/ &
                    8,7,8,6,5,6,8,7,8,4,3,4,2,1,2,4,3,4,8,7,8,6,5,6,8,7,8, &  !ind=1
                    7,8,7,5,6,5,7,8,7,3,4,3,1,2,1,3,4,3,7,8,7,5,6,5,7,8,7, &  !ind=2
                    6,5,6,8,7,8,6,5,6,2,1,2,4,3,4,2,1,2,6,5,6,8,7,8,6,5,6, &  !ind=3
@@ -66,7 +66,7 @@ module amr_constants
                    3,4,3,1,2,1,3,4,3,7,8,7,5,6,5,7,8,7,3,4,3,1,2,1,3,4,3, &  !ind=6
                    2,1,2,4,3,4,2,1,2,6,5,6,8,7,8,6,5,6,2,1,2,4,3,4,2,1,2, &  !ind=7
                    1,2,1,3,4,3,1,2,1,5,6,5,7,8,7,5,6,5,1,2,1,3,4,3,1,2,1  &  !ind=8
-                                 /), shape=(/twotondim,threetondim/), order=(/2,1/))
+                                               /), shape=(/threetondim,twotondim/))
 #endif
 
 end module amr_constants

--- a/amr/amr_constants.f90
+++ b/amr/amr_constants.f90
@@ -20,33 +20,33 @@ module amr_constants
                                        /), shape=(/3,2,8/), order=(/3,2,1/))
 
 #if NDIM==1
-  integer,dimension(1:threetondim,1:twotondim),parameter::lll=reshape( (/ &
+  integer,dimension(1:twotondim,1:threetondim),parameter::lll=reshape( (/ &
                                                                    2,1,1, &  !ind=1
                                                                    1,1,2  &  !ind=2
-                                               /), shape=(/threetondim,twotondim/))
+                                 /), shape=(/twotondim,threetondim/), order=(/2,1/))
 
-  integer,dimension(1:threetondim,1:twotondim),parameter::mmm=reshape( (/ &
+  integer,dimension(1:twotondim,1:threetondim),parameter::mmm=reshape( (/ &
                                                                    2,1,2, &  !ind=1
                                                                    1,2,1  &  !ind=2
-                                               /), shape=(/threetondim,twotondim/))
+                                 /), shape=(/twotondim,threetondim/), order=(/2,1/))
 
 #elif NDIM==2
-  integer,dimension(1:threetondim,1:twotondim),parameter::lll=reshape( (/ &
+  integer,dimension(1:twotondim,1:threetondim),parameter::lll=reshape( (/ &
                                                        4,3,3,2,1,1,2,1,1, &  !ind=1
                                                        3,3,4,1,1,2,1,1,2, &  !ind=2
                                                        2,1,1,2,1,1,4,3,3, &  !ind=3
                                                        1,1,2,1,1,2,3,3,4  &  !ind=4
-                                               /), shape=(/threetondim,twotondim/))
+                                 /), shape=(/twotondim,threetondim/), order=(/2,1/))
 
-  integer,dimension(1:threetondim,1:twotondim),parameter::mmm=reshape( (/ &
+  integer,dimension(1:twotondim,1:threetondim),parameter::mmm=reshape( (/ &
                                                        4,3,4,2,1,2,4,3,4, &  !ind=1
                                                        3,4,3,1,2,1,3,4,3, &  !ind=2
                                                        2,1,2,4,3,4,2,1,2, &  !ind=3
                                                        1,2,1,3,4,3,1,2,1  &  !ind=4
-                                               /), shape=(/threetondim,twotondim/))
+                                 /), shape=(/twotondim,threetondim/), order=(/2,1/))
 
 #elif NDIM==3
-  integer,dimension(1:threetondim,1:twotondim),parameter::lll=reshape( (/ &
+  integer,dimension(1:twotondim,1:threetondim),parameter::lll=reshape( (/ &
                    8,7,7,6,5,5,6,5,5,4,3,3,2,1,1,2,1,1,4,3,3,2,1,1,2,1,1, &  !ind=1
                    7,7,8,5,5,6,5,5,6,3,3,4,1,1,2,1,1,2,3,3,4,1,1,2,1,1,2, &  !ind=2
                    6,5,5,6,5,5,8,7,7,2,1,1,2,1,1,4,3,3,2,1,1,2,1,1,4,3,3, &  !ind=3
@@ -55,9 +55,9 @@ module amr_constants
                    3,3,4,1,1,2,1,1,2,3,3,4,1,1,2,1,1,2,7,7,8,5,5,6,5,5,6, &  !ind=6
                    2,1,1,2,1,1,4,3,3,2,1,1,2,1,1,4,3,3,6,5,5,6,5,5,8,7,7, &  !ind=7
                    1,1,2,1,1,2,3,3,4,1,1,2,1,1,2,3,3,4,5,5,6,5,5,6,7,7,8  &  !ind=8
-                                               /), shape=(/threetondim,twotondim/))
+                                 /), shape=(/twotondim,threetondim/), order=(/2,1/))
 
-  integer,dimension(1:threetondim,1:twotondim),parameter::mmm=reshape( (/ &
+  integer,dimension(1:twotondim,1:threetondim),parameter::mmm=reshape( (/ &
                    8,7,8,6,5,6,8,7,8,4,3,4,2,1,2,4,3,4,8,7,8,6,5,6,8,7,8, &  !ind=1
                    7,8,7,5,6,5,7,8,7,3,4,3,1,2,1,3,4,3,7,8,7,5,6,5,7,8,7, &  !ind=2
                    6,5,6,8,7,8,6,5,6,2,1,2,4,3,4,2,1,2,6,5,6,8,7,8,6,5,6, &  !ind=3
@@ -66,7 +66,7 @@ module amr_constants
                    3,4,3,1,2,1,3,4,3,7,8,7,5,6,5,7,8,7,3,4,3,1,2,1,3,4,3, &  !ind=6
                    2,1,2,4,3,4,2,1,2,6,5,6,8,7,8,6,5,6,2,1,2,4,3,4,2,1,2, &  !ind=7
                    1,2,1,3,4,3,1,2,1,5,6,5,7,8,7,5,6,5,1,2,1,3,4,3,1,2,1  &  !ind=8
-                                               /), shape=(/threetondim,twotondim/))
+                                 /), shape=(/twotondim,threetondim/), order=(/2,1/))
 #endif
 
 end module amr_constants

--- a/amr/flag_utils.f90
+++ b/amr/flag_utils.f90
@@ -223,7 +223,6 @@ subroutine ensure_ref_rules(ilevel)
   integer::i,ind,iskip,igrid,ngrid,ncache
   integer,dimension(1:nvector),save::ind_cell,ind_grid
   integer,dimension(1:nvector,1:threetondim),save::nbors_father_cells
-  integer,dimension(1:nvector,1:twotondim),save::nbors_father_grids
   logical,dimension(1:nvector),save::ok
 
   ncache=active(ilevel)%ngrid
@@ -238,7 +237,7 @@ subroutine ensure_ref_rules(ilevel)
      do i=1,ngrid
         ind_cell(i)=father(ind_grid(i))
      end do
-     call get3cubefather(ind_cell,nbors_father_cells,nbors_father_grids,ngrid,ilevel)
+     call get3cubefather(ind_cell,nbors_father_cells,ngrid,ilevel)
 
      do i=1,ngrid
         ok(i)=.true.

--- a/amr/nbors_utils.f90
+++ b/amr/nbors_utils.f90
@@ -1,26 +1,44 @@
+! This file contains subroutines to obtains neighboring cells 
+! or grids. There are several options, depending on your needs:
+!   * get3cubefather: give the 
+!
+!
+!
+!   * getnborcells: obtain the 2**ndim direct neighboring cells
+!                   of a cell at position ind in a grid.
+!                   The result contains only the neighbors, not
+!                   the cell itself.
+!                   The input for this function is the output of
+!                   getnborgrids and ind.
+
+!   * getnborgrids: obtain the 2**ndim direct neighboring grids
+!                   of a grid. The result includes the grid itself
+!                   at position 0 in the array.
+!                   Often called before getnborcells.
+! 
 !##############################################################
 !##############################################################
 !##############################################################
 !##############################################################
-subroutine get3cubefather(ind_cell_father,nbors_father_cells,ncell,ilevel)
-  use amr_commons
+subroutine get3cubefather(ind_cell,nbor_cells,ncell,ilevel)
+  use amr_parameters, only:nx,ny,nz,ndim,ngridmax,nvector,threetondim
+  use amr_commons, only:ncoarse
   implicit none
   integer,intent(in)::ncell,ilevel
-  integer,dimension(1:nvector),intent(in)::ind_cell_father  ! input cell
-  !3x3x3 neighbors of input cell (including the center input cell)
-  integer,dimension(1:nvector,1:threetondim),intent(out)::nbors_father_cells
+  integer,dimension(1:nvector),intent(in)::ind_cell
+  integer,dimension(1:nvector,1:threetondim),intent(out)::nbor_cells
   !------------------------------------------------------------------
-  ! This subroutine determines the 3^ndim neighboring (including diagonal) cells
-  ! of the input cell. According to the refinement rule,
-  ! they should be present anytime.
-  ! For example in 3D, as output, nbors_father_cells contains the cube of 27 cells 
-  ! around, and including, ind_cell_father.
+  ! This subroutine determines the 3^ndim neighboring cells
+  ! of the input cell ind_cell. This includes diagonal neighbors and 
+  ! the center input cell itself.
+  ! For example in 3D, as output, nbor_cells contains the 3x3x3 cube
+  ! of 27 cells around, and including, ind_cell.
+  ! According to the refinement rule, they should be present anytime.
   !------------------------------------------------------------------
   integer::i,j,nxny,i1,j1,k1,ind,iok,iskip
   integer::i1min,i1max,j1min,j1max,k1min,k1max,ind_father
   integer,dimension(1:nvector),save::ix,iy,iz,iix,iiy,iiz
-  integer,dimension(1:nvector),save::pos,ind_grid_father,ind_grid_ok,ind_cell_ok
-  integer,dimension(1:nvector,1:threetondim),save::nbors_father_ok
+  integer,dimension(1:nvector),save::pos,ind_grid_father
 
   nxny=nx*ny
 
@@ -29,9 +47,9 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,ncell,ilevel)
      ! (because currently only cubic domains are supported, meaning 
      ! there is only 1 root cell)
      do i=1,ncell
-        iz(i)=(ind_cell_father(i)-1)/nxny
-        iy(i)=(ind_cell_father(i)-1-iz(i)*nxny)/nx
-        ix(i)=(ind_cell_father(i)-1-iy(i)*nx-iz(i)*nxny)
+        iz(i)=(ind_cell(i)-1)/nxny
+        iy(i)=(ind_cell(i)-1-iz(i)*nxny)/nx
+        ix(i)=(ind_cell(i)-1-iy(i)*nx-iz(i)*nxny)
      end do
 
      i1min=0; i1max=2
@@ -40,7 +58,8 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,ncell,ilevel)
      k1min=0; k1max=0
      if(ndim > 2)k1max=2
 
-     ! Loop over 3^ndim neighboring father cells
+     ! Loop over 3^ndim neighboring cells by looking 
+     ! left, center and right of the root cell
      do k1=k1min,k1max
         iiz=iz
         if(ndim > 2)then
@@ -70,7 +89,7 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,ncell,ilevel)
               end if
               ind_father=1+i1+3*j1+9*k1
               do i=1,ncell
-                 nbors_father_cells(i,ind_father)=1 &
+                 nbor_cells(i,ind_father)=1 &
                       & +iix(i) &
                       & +iiy(i)*nx &
                       & +iiz(i)*nxny
@@ -81,48 +100,20 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,ncell,ilevel)
 
   else    ! else, more complicated...
 
+     ! Get the cell's position in its grid, that is the
+     ! index ind, between 1 and twotondim.
      do i=1,ncell
-        ! Get father cell position in its grid, that is the
-        ! index ind, between 1 and twotondim.
-        ! Remark that this is an integer division.
-        ! We need to know this to know whether to search neighbors 
-        ! left or right in the AMR tree
-        pos(i)=(ind_cell_father(i)-ncoarse-1)/ngridmax+1
-        ! convert cell index to grid index to get the grid to which the cell belongs
-        iskip=ncoarse+(pos(i)-1)*ngridmax
-        ind_grid_father(i)=ind_cell_father(i)-iskip
+        pos(i)=(ind_cell(i)-ncoarse-1)/ngridmax+1  !integer devision
      end do
 
-     call get3cubepos(ind_grid_father,pos,nbors_father_cells,ncell)
+     ! Convert the cell's index to the index of the grid to which the cell belongs
+     do i=1,ncell
+        iskip=ncoarse+(pos(i)-1)*ngridmax
+        ind_grid_father(i)=ind_cell(i)-iskip
+     end do
 
-     ! Loop over position
-     ! TC: we could just call 
-     !do ind=1,twotondim
-
-        ! Gather father cells that sit at position ind
-        ! TC this is to make call to get3cubepos vectorizable?
-        ! could just make ind an nvector array?
-        !iok=0
-        !do i=1,ncell
-        !   if(pos(i)==ind)then
-        !      iok=iok+1
-         !     ind_grid_ok(iok)=ind_grid_father(i)
-         !     ind_cell_ok(iok)=i
-         !  end if
-        !end do
-
-        !if(iok>0)then
-        !   call get3cubepos(ind_grid_ok,ind,nbors_father_ok,iok)
-!
-           ! Store neighboring father cells for selected cells
- !          do j=1,threetondim
-  !!            do i=1,iok
-    !             nbors_father_cells(ind_cell_ok(i),j)=nbors_father_ok(i,j)
-     !!         end do
-       !    end do
-        !end if
-
-     !end do
+     ! Using the grid index and cell position, get the neighbor cells
+     call get3cubepos(ind_grid_father,pos,nbor_cells,ncell)
 
   end if
 
@@ -131,15 +122,15 @@ end subroutine get3cubefather
 !##############################################################
 !##############################################################
 !##############################################################
-subroutine get3cubefather_grids(ind_cell_father,nbors_father_grids,ncell,ilevel)
+subroutine get3cubefather_grids(ind_cell,nbors_grids,ncell,ilevel)
   use amr_commons
   implicit none
   integer,intent(in)::ncell,ilevel
-  integer,dimension(1:nvector),intent(in)::ind_cell_father
-  integer,dimension(1:nvector,1:twotondim),intent(out)::nbors_father_grids
+  integer,dimension(1:nvector),intent(in)::ind_cell
+  integer,dimension(1:nvector,1:twotondim),intent(out)::nbors_grids
   !------------------------------------------------------------------
-  ! This subroutine determines the 2^ndim neighboring father grids
-  ! of the input father cell. According to the refinement rule,
+  ! This subroutine determines the 2^ndim neighboring grids
+  ! of the input cell. According to the refinement rule,
   ! they should be present anytime.
   !
   ! example 1D:
@@ -151,7 +142,7 @@ subroutine get3cubefather_grids(ind_cell_father,nbors_father_grids,ncell,ilevel)
   integer::i,j,nxny,i1,j1,k1,ind,iok,iskip
   integer::i1min,i1max,j1min,j1max,k1min,k1max,ind_father
   integer,dimension(1:nvector),save::ix,iy,iz,iix,iiy,iiz
-  integer,dimension(1:nvector),save::pos,ind_grid_father,ind_grid_ok,ind_cell_ok
+  integer,dimension(1:nvector),save::pos,ind_grid_father
   integer,dimension(1:nvector,1:twotondim),save::nbors_grids_ok
 
   nxny=nx*ny
@@ -159,9 +150,9 @@ subroutine get3cubefather_grids(ind_cell_father,nbors_father_grids,ncell,ilevel)
   if(ilevel==1)then  ! Easy...
 
      do i=1,ncell
-        iz(i)=(ind_cell_father(i)-1)/nxny
-        iy(i)=(ind_cell_father(i)-1-iz(i)*nxny)/nx
-        ix(i)=(ind_cell_father(i)-1-iy(i)*nx-iz(i)*nxny)
+        iz(i)=(ind_cell(i)-1)/nxny
+        iy(i)=(ind_cell(i)-1-iz(i)*nxny)/nx
+        ix(i)=(ind_cell(i)-1-iy(i)*nx-iz(i)*nxny)
      end do
 
      i1min=0; i1max=2
@@ -200,7 +191,7 @@ subroutine get3cubefather_grids(ind_cell_father,nbors_father_grids,ncell,ilevel)
               end if
               ind_father=1+i1+2*j1+4*k1
               do i=1,ncell
-                 nbors_father_grids(i,ind_father)=1 &
+                 nbors_grids(i,ind_father)=1 &
                       & +(iix(i)/2) &
                       & +(iiy(i)/2)*(nx/2) &
                       & +(iiz(i)/2)*(nxny/4)
@@ -211,43 +202,20 @@ subroutine get3cubefather_grids(ind_cell_father,nbors_father_grids,ncell,ilevel)
 
   else    ! else, more complicated...
 
+     ! Get the cell's position in its grid, that is the
+     ! index ind, between 1 and twotondim.
      do i=1,ncell
-        ! Get father cell position in the grid
-        pos(i)=(ind_cell_father(i)-ncoarse-1)/ngridmax+1
-        ! Get father grid
-        iskip=ncoarse+(pos(i)-1)*ngridmax
-        ind_grid_father(i)=ind_cell_father(i)-iskip
+        pos(i)=(ind_cell(i)-ncoarse-1)/ngridmax+1  !integer devision
      end do
 
-     call get_grids_of_nbor_cells(ind_grid_father,pos,nbors_father_grids,ncell)
+     ! Convert the cell's index to the index of the grid to which the cell belongs
+     do i=1,ncell
+        iskip=ncoarse+(pos(i)-1)*ngridmax
+        ind_grid_father(i)=ind_cell(i)-iskip
+     end do
 
-     ! Loop over position
-     !do ind=1,twotondim
-
-        ! Select father cells that sit at position ind
-        !iok=0
-        !do i=1,ncell
-        !   if(pos(i)==ind)then
-        !      iok=iok+1
-        !      ind_grid_ok(iok)=ind_grid_father(i)
-        !      ind_cell_ok(iok)=i
-        !   end if
-        !end do
-
-        !if(iok>0)then
-           ! Get the grids that contain the 3x3x3 neighbor cells of
-           ! the cell at position ind in the grid ind_grid_ok
-        !   call get_grids_of_nbor_cells(ind_grid_ok,ind,nbors_grids_ok,iok)
-
-           ! Store neighboring father grids for selected cells
-         !  do j=1,twotondim
-         !     do i=1,iok
-         !        nbors_father_grids(ind_cell_ok(i),j)=nbors_grids_ok(i,j)
-         !     end do
-         !  end do
-        !endif
-
-    ! end do
+     ! Using the 
+     call get_grids_of_nbor_cells(ind_grid_father,pos,nbors_grids,ncell)
 
   end if
 
@@ -275,36 +243,39 @@ subroutine get3cubepos(ind_grid,ind,nbors_cells,ng)
   !                       containing
   !              ||  cell=ind  | another cell ||
   !
-  !   First, the grids of that contain the neighbors are determined by
+  !   The grids of that contain the neighbors are determined by
   !   the subroutine get_grids_of_nbor_cells:
   !
   !     ||   NBOR GRID   ||    IND_GRID   || 
   !     || cell |  nbor  ||  IND  |  nbor ||
   !
+  !   Then, to extract the cells from the grids, we use the indices from 
+  !   lll and mmm
+  !
   !--------------------------------------------------------------------
   integer::i,j,iskip
   integer::icell,igrid
   integer,dimension(1:nvector,1:twotondim),save::nbors_grids
-  integer,dimension(1:threetondim),save::lll_loc,mmm_loc
+  integer,dimension(1:twotondim),save::lll_loc,mmm_loc
 
   ! Get the grids that contain all neighbor cells
   call get_grids_of_nbor_cells(ind_grid,ind,nbors_grids,ng)
 
-  ! Fetch magic indices
-  !lll_loc = lll!(:,ind)
-  !mmm_loc = mmm!(:,ind)
-
-  ! Loop over 3x3x3 neighbor cells
+  ! Extract each of the 3x3x3 neighbor cells out of the grids
   do j=1,threetondim
-     ! index in the list of nbor_grids of the grid in which the j-th neighbor cell should be located
-     !igrid=lll_loc(j)
-     ! position in which the neighbor cell should be located in its grid
-     !icell=mmm_loc(j)
-     !iskip=ncoarse+(icell-1)*ngridmax
+
+     ! Fetch magic indices
+     lll_loc = lll(j,:)
+     mmm_loc = mmm(j,:)
+
      do i=1,ng
-        igrid = lll(j,ind(i))
-        icell = mmm(j,ind(i))
+        ! index in the list of nbor_grids of the grid in which the j-th neighbor cell should be located
+        igrid = lll_loc(ind(i))
+        ! position in which the neighbor cell should be located in its grid
+        icell = mmm_loc(ind(i))
+
         iskip=ncoarse+(icell-1)*ngridmax
+
         ! If the grid for neighbor cell j exists,
         ! determine its index based on the index of the grid in which is sits
         ! otherwise set 0.
@@ -353,7 +324,7 @@ subroutine get_grids_of_nbor_cells(ind_grid,ind,nbors_grids,ng)
   !                     || SON GRID OF NBOR ||  IND_GRID  || son grid of nbor ||
   !                     ||  cell   | nbor   || ind  | nbor||  cell  |   cell  ||
   ! 
-  ! so the output in this case is the left and middle grid (in capital letters).
+  !   In this example, the requested grids are the left and middle grid (in capital letters).
   !--------------------------------------------------------------------
   integer::i,inbor
   integer::ii,iimin,iimax
@@ -375,10 +346,9 @@ subroutine get_grids_of_nbor_cells(ind_grid,ind,nbors_grids,ng)
         ind_grid1(i)=ind_grid(i)
      end do
      if(kk>0)then
-        !inbor=kkk(ind)
         do i=1,ng
            if(ind_grid(i)>0)then
-              ind_grid1(i)=son(nbor(ind_grid(i),kkk(ind(i))))!inbor))
+              ind_grid1(i)=son(nbor(ind_grid(i),kkk(ind(i))))
            endif
         end do
      end if
@@ -388,10 +358,9 @@ subroutine get_grids_of_nbor_cells(ind_grid,ind,nbors_grids,ng)
            ind_grid2(i)=ind_grid1(i)
         end do
         if(jj>0)then
-           !inbor=jjj(ind)
            do i=1,ng
               if(ind_grid1(i)>0)then
-                 ind_grid2(i)=son(nbor(ind_grid1(i),jjj(ind(i))))!inbor))
+                 ind_grid2(i)=son(nbor(ind_grid1(i),jjj(ind(i))))
               endif
            end do
         end if
@@ -401,10 +370,9 @@ subroutine get_grids_of_nbor_cells(ind_grid,ind,nbors_grids,ng)
               ind_grid3(i)=ind_grid2(i)
            end do
            if(ii>0)then
-              !inbor=iii(ind)
               do i=1,ng
                  if(ind_grid2(i)>0)then
-                    ind_grid3(i)=son(nbor(ind_grid2(i),iii(ind(i))))!inbor))
+                    ind_grid3(i)=son(nbor(ind_grid2(i),iii(ind(i))))
                  endif
               end do
            end if
@@ -423,35 +391,38 @@ end subroutine get_grids_of_nbor_cells
 !##############################################################
 !##############################################################
 !##############################################################
-subroutine getnborcells(igridn,ind,icelln,ng)
+subroutine getnborcells(nbors_grids,ind,ind_cell,ng)
   use amr_commons
   use amr_constants, only:iii,jjj
   implicit none
   integer,intent(in)::ng,ind
-  integer,dimension(1:nvector,0:twondim),intent(in)::igridn
-  integer,dimension(1:nvector,1:twondim),intent(out)::icelln
+  integer,dimension(1:nvector,0:twondim),intent(in)::nbors_grids
+  integer,dimension(1:nvector,1:twondim),intent(out)::ind_cell
   !--------------------------------------------------------------
-  ! This routine computes the index of 6-neighboring cells
-  ! The user must provide igridn = index of the 6 neighboring
-  ! grids and the cell's grid (see routine getnborgrids).
-  ! ind is the cell index in the grid.
+  ! This routine computes the index of 6-neighboring cells (non-diagonal).
+  ! The user must provide nbors_grids = index of the 6 neighboring
+  ! grids with the cell's grid at position 0 in the list,
+  ! as returned by the routine getnborgrids.
+  ! ind is the position index of the center cell in its grid.
   !--------------------------------------------------------------
-  integer::i,in,ig,ih,iskip,inbor,idim
+  integer::i,in,igrid,icell,iskip,inbor,idim
 
-  ! Reset indices
-  !icelln(1:ng,1:twondim)=0
-  ! Compute cell numbers
+  ! Extract, out of the input grids, the left and right 
+  ! neighbor cell in each dimension.
   do inbor=1,2
      do idim=1,ndim
+        ! index for neighbor order
         in=(idim-1)*2 + inbor
-        ig=iii(idim,inbor,ind)
-        ih=jjj(idim,inbor,ind)
-        iskip=ncoarse+(ih-1)*ngridmax
+        ! index in the input list nbors_grids, of the grid in which the j-th neighbor cell should be located
+        igrid=iii(idim,inbor,ind)
+        ! position in which the neighbor cell should be located in its grid
+        icell=jjj(idim,inbor,ind)
+
+        iskip=ncoarse+(icell-1)*ngridmax
         do i=1,ng
-           icelln(i,in)=merge(iskip+igridn(i,ig), 0, (igridn(i,ig)>0))
-           !if(igridn(i,ig)>0)then
-           !   icelln(i,in)=iskip+igridn(i,ig)
-           !end if
+           ind_cell(i,in)=merge(iskip+nbors_grids(i,igrid), & !if-part
+                            &                            0, & !else-part
+                            &       (nbors_grids(i,igrid)>0)) !condition
         end do
      enddo
   end do
@@ -473,10 +444,10 @@ subroutine getnborfather(ind_cell,ind_father,ncell,ilevel)
   ! If for some reasons they don't exist, the routine returns
   ! the neighboring father cells of the input cell.
   !-----------------------------------------------------------------
-  integer::nxny,i,idim,j,iok,ind
+  integer::nxny,i,idim,j,iok,ind,iskip
   integer,dimension(1:3)::ibound,iskip1,iskip2
   integer,dimension(1:nvector,1:3),save::ix
-  integer,dimension(1:nvector),save::ind_grid_father,pos
+  integer,dimension(1:nvector),save::ind_grid,pos
   integer,dimension(1:nvector,0:twondim),save::igridn,igridn_ok,icell_ok
   integer,dimension(1:nvector,1:twondim),save::icelln_ok
 
@@ -529,14 +500,24 @@ subroutine getnborfather(ind_cell,ind_father,ncell,ilevel)
      do i=1,ncell
         ! Get father cell
         ind_father(i,0)=ind_cell(i)
-        ! Get father cell position in the grid
-        pos(i)=(ind_father(i,0)-ncoarse-1)/ngridmax+1
-        ! Get father grid
-        ind_grid_father(i)=ind_father(i,0)-ncoarse-(pos(i)-1)*ngridmax
      end do
 
-     ! Get neighboring father grids
-     call getnborgrids(ind_grid_father,igridn,ncell)
+     ! Get the cell's position in its grid, that is the
+     ! index ind, between 1 and twotondim.
+     do i=1,ncell
+        pos(i)=(ind_cell(i)-ncoarse-1)/ngridmax+1  !integer devision
+     end do
+
+     ! Convert the cell's index to the index of the grid to which the cell belongs
+     do i=1,ncell
+        iskip=ncoarse+(pos(i)-1)*ngridmax
+        ind_grid(i)=ind_cell(i)-iskip
+     end do
+
+     ! Get the 2**ndim neighboring grids of the grid
+     call getnborgrids(ind_grid,igridn,ncell)
+
+     ! TODO same trick to get rid of iok as in get3cubefather?
 
      ! Loop over position
      do ind=1,twotondim
@@ -561,7 +542,7 @@ subroutine getnborfather(ind_cell,ind_father,ncell,ilevel)
            do j=1,twondim
               do i=1,iok
                  ind_father(icell_ok(i,j),j)=merge(icelln_ok(i,j), &
-                                                 & nbor(ind_grid_father(icell_ok(i,j)),j), &
+                                                 & nbor(ind_grid(icell_ok(i,j)),j), &
                                                  &(icelln_ok(i,j)>0))
                  !if(icelln_ok(i,j)>0)then
                  !   ind_father(icell_ok(i,j),j)=icelln_ok(i,j)
@@ -581,30 +562,30 @@ end subroutine getnborfather
 !##############################################################
 !##############################################################
 !##############################################################
-subroutine getnborgrids(igrid,igridn,ngrid)
+subroutine getnborgrids(igrid,igridn,ng)
   use amr_commons
   implicit none
-  integer,intent(in)::ngrid
+  integer,intent(in)::ng
   integer,dimension(1:nvector),intent(in)::igrid
   integer,dimension(1:nvector,0:twondim),intent(out)::igridn
   !---------------------------------------------------------
   ! This routine computes the index of the 2 x ndim neighboring
   ! grids for grid igrid(:). The index for the central
-  ! grid is stored in igridn(:,0). If for some reasons
-  ! the neighboring grids don't exist, then igridn(:,j) = 0.
-  ! TC: =0 is not guaranteed? Yes it is because son is 0
-  ! if son if 0 then its a leaf cell
-  ! TC: is it needed to store igrid? yes for loop?
+  ! grid is stored in igridn(:,0).  We need it for when we want
+  ! to later derive the neighbor cells from these grids (see
+  ! getnborcells).
+  ! If for some reasons the neighboring grids don't exist, 
+  ! then igridn(:,j) = 0 (because son is 0, i.e. it's a leaf cell).
   !---------------------------------------------------------
   integer::i,j
 
-  ! Store central grid
-  do i=1,ngrid
+  ! Store central grid at position 0
+  do i=1,ng
      igridn(i,0)=igrid(i)
   end do
   ! Store neighboring grids
   do j=1,twondim
-     do i=1,ngrid
+     do i=1,ng
         ! nbor(igrid(i),j) is the jth neighbor cell of the father cell
         ! of the grid with index igrid
         ! Son points to the child grid of that cell.
@@ -617,10 +598,10 @@ end subroutine getnborgrids
 !##############################################################
 !##############################################################
 !##############################################################
-subroutine getnborgrids_check(igrid,igridn,ngrid)
+subroutine getnborgrids_check(igrid,igridn,ng)
   use amr_commons
   implicit none
-  integer::ngrid
+  integer::ng
   integer,dimension(1:nvector)::igrid
   integer,dimension(1:nvector,0:twondim)::igridn
   !---------------------------------------------------------
@@ -632,12 +613,12 @@ subroutine getnborgrids_check(igrid,igridn,ngrid)
   integer::i,j
 
   ! Store central grid
-  do i=1,ngrid
+  do i=1,ng
      igridn(i,0)=igrid(i)
   end do
   ! Store neighboring grids
   do j=1,twondim
-     do i=1,ngrid
+     do i=1,ng
         if (nbor(igrid(i),j)>0)igridn(i,j)=son(nbor(igrid(i),j))
      end do
   end do

--- a/amr/nbors_utils.f90
+++ b/amr/nbors_utils.f90
@@ -411,13 +411,13 @@ end subroutine get_grids_of_nbor_cells
 !##############################################################
 !##############################################################
 !##############################################################
-subroutine getnborcells(nbors_grids,ind,ind_cell,ng)
+subroutine getnborcells(igridn,ind,icelln,ng)
   use amr_commons
   use amr_constants, only:iii,jjj
   implicit none
   integer,intent(in)::ng,ind
-  integer,dimension(1:nvector,0:twondim),intent(in)::nbors_grids
-  integer,dimension(1:nvector,1:twondim),intent(out)::ind_cell
+  integer,dimension(1:nvector,0:twondim),intent(in)::igridn
+  integer,dimension(1:nvector,1:twondim),intent(out)::icelln
   !--------------------------------------------------------------
   ! This routine computes the index of 6-neighboring cells (non-diagonal).
   ! The user must provide nbors_grids = index of the 6 neighboring
@@ -426,6 +426,9 @@ subroutine getnborcells(nbors_grids,ind,ind_cell,ng)
   ! ind is the position index of the center cell in its grid.
   !--------------------------------------------------------------
   integer::i,in,igrid,icell,iskip,inbor,idim
+
+  ! Reset indices
+  icelln(1:ng,1:twondim)=0
 
   ! Extract, out of the input grids, the left and right 
   ! neighbor cell in each dimension.
@@ -440,9 +443,9 @@ subroutine getnborcells(nbors_grids,ind,ind_cell,ng)
 
         iskip=ncoarse+(icell-1)*ngridmax
         do i=1,ng
-           ind_cell(i,in)=merge(iskip+nbors_grids(i,igrid), & !if-part
-                            &                            0, & !else-part
-                            &       (nbors_grids(i,igrid)>0)) !condition
+           if(igridn(i,igrid)>0)then
+              icelln(i,in)=iskip+igridn(i,igrid)
+           end if
         end do
      enddo
   end do
@@ -467,8 +470,8 @@ subroutine getnborfather(ind_cell,ind_father,ncell,ilevel)
   integer::nxny,i,idim,j,iok,ind,iskip
   integer,dimension(1:3)::ibound,iskip1,iskip2
   integer,dimension(1:nvector,1:3),save::ix
-  integer,dimension(1:nvector),save::ind_grid,pos
-  integer,dimension(1:nvector,0:twondim),save::igridn,igridn_ok,icell_ok
+  integer,dimension(1:nvector),save::ind_grid_father,pos
+  integer,dimension(1:nvector,0:twondim),save::igridn,igridn_ok
   integer,dimension(1:nvector,1:twondim),save::icelln_ok
 
   nxny=nx*ny
@@ -498,27 +501,25 @@ subroutine getnborfather(ind_cell,ind_father,ncell,ilevel)
 
      do idim=1,ndim
         do i=1,ncell
-           ind_father(i,2*idim-1)=merge(ind_father(i,0)-iskip1(idim), ind_father(i,0)+iskip2(idim), (ix(i,idim)>0))
-           !if(ix(i,idim)>0)then
-           !   ind_father(i,2*idim-1)=ind_father(i,0)-iskip1(idim)
-           !else
-           !   ind_father(i,2*idim-1)=ind_father(i,0)+iskip2(idim)
-           !end if
-        !end do
-        !do i=1,ncell
-           ind_father(i,2*idim)=merge(ind_father(i,0)+iskip1(idim), ind_father(i,0)-iskip2(idim), (ix(i,idim)<ibound(idim)))
-           !if(ix(i,idim)<ibound(idim))then
-           !   ind_father(i,2*idim)=ind_father(i,0)+iskip1(idim)
-           !else
-           !   ind_father(i,2*idim)=ind_father(i,0)-iskip2(idim)
-           !end if
+           if(ix(i,idim)>0)then
+              ind_father(i,2*idim-1)=ind_father(i,0)-iskip1(idim)
+           else
+              ind_father(i,2*idim-1)=ind_father(i,0)+iskip2(idim)
+           end if
+        end do
+        do i=1,ncell
+           if(ix(i,idim)<ibound(idim))then
+              ind_father(i,2*idim)=ind_father(i,0)+iskip1(idim)
+           else
+              ind_father(i,2*idim)=ind_father(i,0)-iskip2(idim)
+           end if
         end do
      end do
 
   else
 
+     ! Get father cell
      do i=1,ncell
-        ! Get father cell
         ind_father(i,0)=ind_cell(i)
      end do
 
@@ -531,13 +532,11 @@ subroutine getnborfather(ind_cell,ind_father,ncell,ilevel)
      ! Convert the cell's index to the index of the grid to which the cell belongs
      do i=1,ncell
         iskip=ncoarse+(pos(i)-1)*ngridmax
-        ind_grid(i)=ind_cell(i)-iskip
+        ind_grid_father(i)=ind_cell(i)-iskip
      end do
 
      ! Get the 2**ndim grids that contain the neighboring cells
-     call getnborgrids(ind_grid,igridn,ncell)
-
-     ! TODO same trick to get rid of iok as in get3cubefather?
+     call getnborgrids(ind_grid_father,igridn,ncell)
 
      ! Loop over position
      do ind=1,twotondim
@@ -549,29 +548,27 @@ subroutine getnborfather(ind_cell,ind_father,ncell,ilevel)
               if(pos(i)==ind)then
                  iok=iok+1
                  igridn_ok(iok,j)=igridn(i,j)
-                 icell_ok(iok,j)=i
               end if
            end do
         end do
 
         ! Get neighboring cells for selected cells
-        if(iok>0) then
-           call getnborcells(igridn_ok,ind,icelln_ok,iok)
+        if(iok>0)call getnborcells(igridn_ok,ind,icelln_ok,iok)
 
-           ! Update neighboring father cells for selected cells
-           do j=1,twondim
-              do i=1,iok
-                 ind_father(icell_ok(i,j),j)=merge(icelln_ok(i,j), &
-                                                 & nbor(ind_grid(icell_ok(i,j)),j), &
-                                                 &(icelln_ok(i,j)>0))
-                 !if(icelln_ok(i,j)>0)then
-                 !   ind_father(icell_ok(i,j),j)=icelln_ok(i,j)
-                 !else
-                 !   ind_father(icell_ok(i,j),j)=nbor(ind_grid_father(icell_ok(i,j)),j)
-                 !end if
-              end do
+        ! Update neighboring father cells for selected cells
+        do j=1,twondim
+           iok=0
+           do i=1,ncell
+              if(pos(i)==ind)then
+                 iok=iok+1
+                 if(icelln_ok(iok,j)>0)then
+                    ind_father(i,j)=icelln_ok(iok,j)
+                 else
+                    ind_father(i,j)=nbor(ind_grid_father(i),j)
+                 end if
+              end if
            end do
-        end if
+        end do
 
      end do
 
@@ -582,10 +579,10 @@ end subroutine getnborfather
 !##############################################################
 !##############################################################
 !##############################################################
-subroutine getnborgrids(igrid,igridn,ng)
+subroutine getnborgrids(igrid,igridn,ngrid)
   use amr_commons
   implicit none
-  integer,intent(in)::ng
+  integer,intent(in)::ngrid
   integer,dimension(1:nvector),intent(in)::igrid
   integer,dimension(1:nvector,0:twondim),intent(out)::igridn
   !---------------------------------------------------------
@@ -600,12 +597,12 @@ subroutine getnborgrids(igrid,igridn,ng)
   integer::i,j
 
   ! Store central grid at position 0
-  do i=1,ng
+  do i=1,ngrid
      igridn(i,0)=igrid(i)
   end do
   ! Store neighboring grids
   do j=1,twondim
-     do i=1,ng
+     do i=1,ngrid
         ! nbor(igrid(i),j) is the jth neighbor cell of the father cell
         ! of the grid with index igrid
         ! Son points to the child grid of that cell.
@@ -618,27 +615,26 @@ end subroutine getnborgrids
 !##############################################################
 !##############################################################
 !##############################################################
-subroutine getnborgrids_check(igrid,igridn,ng)
+subroutine getnborgrids_check(igrid,igridn,ngrid)
   use amr_commons
   implicit none
-  integer::ng
+  integer::ngrid
   integer,dimension(1:nvector)::igrid
   integer,dimension(1:nvector,0:twondim)::igridn
   !---------------------------------------------------------
   ! This routine does EXACTLY the same as getnborgrids
   ! but it checks if the neighbor of igrid exists in order
   ! to avoid son(0) leading to crash.
-  ! TC: doesn't this possibly result in a garbage value for igridn where son was 0? 
   !---------------------------------------------------------
   integer::i,j
 
   ! Store central grid
-  do i=1,ng
+  do i=1,ngrid
      igridn(i,0)=igrid(i)
   end do
   ! Store neighboring grids
   do j=1,twondim
-     do i=1,ng
+     do i=1,ngrid
         if (nbor(igrid(i),j)>0)igridn(i,j)=son(nbor(igrid(i),j))
      end do
   end do

--- a/amr/nbors_utils.f90
+++ b/amr/nbors_utils.f90
@@ -94,9 +94,12 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,ncell,ilevel)
      end do
 
      ! Loop over position
+     ! TC: we could just call 
      do ind=1,twotondim
 
-        ! Select father cells that sit at position ind
+        ! Gather father cells that sit at position ind
+        ! TC this is to make call to get3cubepos vectorizable?
+        ! could just make ind an nvector array?
         iok=0
         do i=1,ncell
            if(pos(i)==ind)then
@@ -228,6 +231,8 @@ subroutine get3cubefather_grids(ind_cell_father,nbors_father_grids,ncell,ilevel)
         end do
 
         if(iok>0)then
+           ! Get the grids that contain the 3x3x3 neighbor cells of
+           ! the cell at position ind in the grid ind_grid_ok
            call get_grids_of_nbor_cells(ind_grid_ok,ind,nbors_grids_ok,iok)
 
            ! Store neighboring father grids for selected cells

--- a/amr/nbors_utils.f90
+++ b/amr/nbors_utils.f90
@@ -1,21 +1,46 @@
-! This file contains subroutines to obtains neighboring cells 
-! or grids. There are several options, depending on your needs:
-!   * get3cubefather: give the 
+! This file contains subroutines to help access neighboring cells or grids.
 !
+!   GETTING 3^NDIM SURROUNDING NEIGHBORS, i.e. 3x3x3 cube incl. diagonal
 !
+!   * get3cubefather: IN: cell, OUT: 3^ndim neighbor cells
+!                     Obtain the neighboring cells of the cell.
+!                     Calls get3cubepos.
 !
-!   * getnborcells: obtain the 2**ndim direct neighboring cells
-!                   of a cell at position ind in a grid.
+!   * get3cubefather_grids: IN: cell, OUT: 2^ndim neighbor grids
+!                           Obtain the grids that contain the neighboring cells.
+!                           Calls get_grids_of_nbor_cells.
+
+!   (*) get3cubepos: IN: grid & ind, OUT: 3^ndim neighbor cells
+!                    Obtain the neighboring cells of a cell sitting at position
+!                    ind in the input grid.
+!                    Helper for get3cubefather. Calls get_grids_of_nbor_cells.
+
+!   (*) get_grids_of_nbor_cells: IN: grid & ind, OUT: 2^ndim neighbor grids
+!                                Obtain the grids that contain the neighbor cells 
+!                                of a cell sitting at position ind in the input grid.
+!                                Helper for get3cubepos and get3cubefather_grids.
+!
+!   GETTING 2xNDIM DIRECT NEIGHBORS
+!
+!   * getnborfather: IN: cell, OUT: 2*ndim neighbor cells
+!                    Obtain the direct neighboring cells of the cell.
+!                    Calls getnborgrids and getnborcells.
+!
+!   * getnborgrids: IN: grid, OUT: 2*ndim neighbor grids
+!                   Obtain the direct neighboring grids of a grid. 
+!                   The result includes the grid itself at
+!                   position 0 in the array.
+!                   Often called before getnborcells.
+!
+!   * getnborcells: IN: neighbor grids & ind, OUT: 2*ndim neighbor cells
+!                   Obtain the 2*ndim direct neighboring cells
+!                   of a cell at position ind in its grid, of which the neighbor
+!                   grids are provided.
 !                   The result contains only the neighbors, not
 !                   the cell itself.
 !                   The input for this function is the output of
 !                   getnborgrids and ind.
-
-!   * getnborgrids: obtain the 2**ndim direct neighboring grids
-!                   of a grid. The result includes the grid itself
-!                   at position 0 in the array.
-!                   Often called before getnborcells.
-! 
+!
 !##############################################################
 !##############################################################
 !##############################################################
@@ -129,15 +154,10 @@ subroutine get3cubefather_grids(ind_cell,nbors_grids,ncell,ilevel)
   integer,dimension(1:nvector),intent(in)::ind_cell
   integer,dimension(1:nvector,1:twotondim),intent(out)::nbors_grids
   !------------------------------------------------------------------
-  ! This subroutine determines the 2^ndim neighboring grids
-  ! of the input cell. According to the refinement rule,
-  ! they should be present anytime.
-  !
-  ! example 1D:
-  !
-  !           ||           father grid             || the other neighbor father grid ||
-  !           || neighbor cell |  IND CELL FATHER  || neighbor cell  | neighbor cell ||
-  ! TC: not sure this is correct
+  ! This subroutine determines the two^ndim grids that contain the
+  ! 3x3x3 neighboring cells of the cell ind_cell.
+  ! According to the refinement rule,they should be present anytime.
+  ! Example 1D: see get_grids_of_nbor_cells.
   !------------------------------------------------------------------
   integer::i,j,nxny,i1,j1,k1,ind,iok,iskip
   integer::i1min,i1max,j1min,j1max,k1min,k1max,ind_father
@@ -214,7 +234,7 @@ subroutine get3cubefather_grids(ind_cell,nbors_grids,ncell,ilevel)
         ind_grid_father(i)=ind_cell(i)-iskip
      end do
 
-     ! Using the 
+     ! Using the grid index and cell position to get neighbor grids
      call get_grids_of_nbor_cells(ind_grid_father,pos,nbors_grids,ncell)
 
   end if
@@ -514,7 +534,7 @@ subroutine getnborfather(ind_cell,ind_father,ncell,ilevel)
         ind_grid(i)=ind_cell(i)-iskip
      end do
 
-     ! Get the 2**ndim neighboring grids of the grid
+     ! Get the 2**ndim grids that contain the neighboring cells
      call getnborgrids(ind_grid,igridn,ncell)
 
      ! TODO same trick to get rid of iok as in get3cubefather?

--- a/amr/nbors_utils.f90
+++ b/amr/nbors_utils.f90
@@ -285,8 +285,8 @@ subroutine get3cubepos(ind_grid,ind,nbors_cells,ng)
   do j=1,threetondim
 
      ! Fetch magic indices
-     lll_loc = lll(j,:)
-     mmm_loc = mmm(j,:)
+     lll_loc = lll(:,j)
+     mmm_loc = mmm(:,j)
 
      do i=1,ng
         ! index in the list of nbor_grids of the grid in which the j-th neighbor cell should be located

--- a/amr/nbors_utils.f90
+++ b/amr/nbors_utils.f90
@@ -6,16 +6,17 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,ncell,ilevel)
   use amr_commons
   implicit none
   integer,intent(in)::ncell,ilevel
-  integer,dimension(1:nvector),intent(in)::ind_cell_father
+  integer,dimension(1:nvector),intent(in)::ind_cell_father  ! input cell
+  !3x3x3 neighbors of input cell (including the center input cell)
   integer,dimension(1:nvector,1:threetondim),intent(out)::nbors_father_cells
   !------------------------------------------------------------------
-  ! This subroutine determines the 3^ndim neighboring father cells
-  ! of the input father cell. According to the refinement rule,
+  ! This subroutine determines the 3^ndim neighboring (including diagonal) cells
+  ! of the input cell. According to the refinement rule,
   ! they should be present anytime.
   ! For example in 3D, as output, nbors_father_cells contains the cube of 27 cells 
   ! around, and including, ind_cell_father.
   !------------------------------------------------------------------
-  integer::i,j,nxny,i1,j1,k1,ind,iok
+  integer::i,j,nxny,i1,j1,k1,ind,iok,iskip
   integer::i1min,i1max,j1min,j1max,k1min,k1max,ind_father
   integer,dimension(1:nvector),save::ix,iy,iz,iix,iiy,iiz
   integer,dimension(1:nvector),save::pos,ind_grid_father,ind_grid_ok,ind_cell_ok
@@ -24,7 +25,9 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,ncell,ilevel)
   nxny=nx*ny
 
   if(ilevel==1)then  ! Easy...
-     if(myid==1)write(*,*)'NCELL',ncell
+     ! ncell is always 1 in this case
+     ! (because currently only cubic domains are supported, meaning 
+     ! there is only 1 root cell)
      do i=1,ncell
         iz(i)=(ind_cell_father(i)-1)/nxny
         iy(i)=(ind_cell_father(i)-1-iz(i)*nxny)/nx
@@ -43,10 +46,8 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,ncell,ilevel)
         if(ndim > 2)then
            do i=1,ncell
               iiz(i)=iz(i)+k1-1
-              iiz(i)=merge(nz-1, iiz(i), (iiz(i) < 0))
-              iiz(i)=merge(   0, iiz(i), (iiz(i) > nz-1))
-              !if(iiz(i) < 0   )iiz(i)=nz-1
-              !if(iiz(i) > nz-1)iiz(i)=0
+              if(iiz(i) < 0   )iiz(i)=nz-1
+              if(iiz(i) > nz-1)iiz(i)=0
            end do
         end if
         do j1=j1min,j1max
@@ -54,10 +55,8 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,ncell,ilevel)
            if(ndim > 1)then
               do i=1,ncell
                  iiy(i)=iy(i)+j1-1
-                 iiy(i)=merge(ny-1, iiy(i), (iiy(i) < 0))
-                 iiy(i)=merge(   0, iiy(i), (iiy(i) > ny-1))
-                 !if(iiy(i) < 0   )iiy(i)=ny-1
-                 !if(iiy(i) > ny-1)iiy(i)=0
+                 if(iiy(i) < 0   )iiy(i)=ny-1
+                 if(iiy(i) > ny-1)iiy(i)=0
               end do
            end if
            do i1=i1min,i1max
@@ -65,10 +64,8 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,ncell,ilevel)
               if(ndim > 0)then
                  do i=1,ncell
                     iix(i)=ix(i)+i1-1
-                    iix(i)=merge(nx-1, iix(i), (iix(i) < 0))
-                    iix(i)=merge(   0, iix(i), (iix(i) > nx-1))
-                    !if(iix(i) < 0   )iix(i)=nx-1
-                    !if(iix(i) > nx-1)iix(i)=0
+                    if(iix(i) < 0   )iix(i)=nx-1
+                    if(iix(i) > nx-1)iix(i)=0
                  end do
               end if
               ind_father=1+i1+3*j1+9*k1
@@ -85,10 +82,15 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,ncell,ilevel)
   else    ! else, more complicated...
 
      do i=1,ncell
-        ! Get father cell position in the grid
+        ! Get father cell position in its grid, that is the
+        ! index ind, between 1 and twotondim.
+        ! Remark that this is an integer division.
+        ! We need to know this to know whether to search neighbors 
+        ! left or right in the AMR tree
         pos(i)=(ind_cell_father(i)-ncoarse-1)/ngridmax+1
-        ! Get father grid
-        ind_grid_father(i)=ind_cell_father(i)-ncoarse-(pos(i)-1)*ngridmax
+        ! convert cell index to grid index to get the grid to which the cell belongs
+        iskip=ncoarse+(pos(i)-1)*ngridmax
+        ind_grid_father(i)=ind_cell_father(i)-iskip
      end do
 
      ! Loop over position
@@ -141,7 +143,7 @@ subroutine get3cubefather_grids(ind_cell_father,nbors_father_grids,ncell,ilevel)
   !           || neighbor cell |  IND CELL FATHER  || neighbor cell  | neighbor cell ||
   ! TC: not sure this is correct
   !------------------------------------------------------------------
-  integer::i,j,nxny,i1,j1,k1,ind,iok
+  integer::i,j,nxny,i1,j1,k1,ind,iok,iskip
   integer::i1min,i1max,j1min,j1max,k1min,k1max,ind_father
   integer,dimension(1:nvector),save::ix,iy,iz,iix,iiy,iiz
   integer,dimension(1:nvector),save::pos,ind_grid_father,ind_grid_ok,ind_cell_ok
@@ -169,10 +171,8 @@ subroutine get3cubefather_grids(ind_cell_father,nbors_father_grids,ncell,ilevel)
         if(ndim > 2)then
            do i=1,ncell
               iiz(i)=iz(i)+2*k1-1
-              iiz(i)=merge(nz-1, iiz(i), (iiz(i) < 0))
-              iiz(i)=merge(   0, iiz(i), (iiz(i) > nz-1))
-              !if(iiz(i) < 0   )iiz(i)=nz-1
-              !if(iiz(i) > nz-1)iiz(i)=0
+              if(iiz(i) < 0   )iiz(i)=nz-1
+              if(iiz(i) > nz-1)iiz(i)=0
            end do
         end if
         do j1=j1min,j1max
@@ -180,10 +180,8 @@ subroutine get3cubefather_grids(ind_cell_father,nbors_father_grids,ncell,ilevel)
            if(ndim > 1)then
               do i=1,ncell
                  iiy(i)=iy(i)+2*j1-1
-                 iiy(i)=merge(ny-1, iiy(i), (iiy(i) < 0))
-                 iiy(i)=merge(   0, iiy(i), (iiy(i) > ny-1))
-                 !if(iiy(i) < 0   )iiy(i)=ny-1
-                 !if(iiy(i) > ny-1)iiy(i)=0
+                 if(iiy(i) < 0   )iiy(i)=ny-1
+                 if(iiy(i) > ny-1)iiy(i)=0
               end do
            end if
            do i1=i1min,i1max
@@ -191,10 +189,8 @@ subroutine get3cubefather_grids(ind_cell_father,nbors_father_grids,ncell,ilevel)
               if(ndim > 0)then
                  do i=1,ncell
                     iix(i)=ix(i)+2*i1-1
-                    iix(i)=merge(nx-1, iix(i), (iix(i) < 0))
-                    iix(i)=merge(   0, iix(i), (iix(i) > nx-1))
-                    !if(iix(i) < 0   )iix(i)=nx-1
-                    !if(iix(i) > nx-1)iix(i)=0
+                    if(iix(i) < 0   )iix(i)=nx-1
+                    if(iix(i) > nx-1)iix(i)=0
                  end do
               end if
               ind_father=1+i1+2*j1+4*k1
@@ -209,13 +205,13 @@ subroutine get3cubefather_grids(ind_cell_father,nbors_father_grids,ncell,ilevel)
      end do
 
   else    ! else, more complicated...
-     !TC: can this be simplified now?
 
      do i=1,ncell
         ! Get father cell position in the grid
         pos(i)=(ind_cell_father(i)-ncoarse-1)/ngridmax+1
         ! Get father grid
-        ind_grid_father(i)=ind_cell_father(i)-ncoarse-(pos(i)-1)*ngridmax
+        iskip=ncoarse+(pos(i)-1)*ngridmax
+        ind_grid_father(i)=ind_cell_father(i)-iskip
      end do
 
      ! Loop over position
@@ -232,7 +228,7 @@ subroutine get3cubefather_grids(ind_cell_father,nbors_father_grids,ncell,ilevel)
         end do
 
         if(iok>0)then
-           call get_nbor_grids(ind_grid_ok,ind,nbors_grids_ok,iok)
+           call get_grids_of_nbor_cells(ind_grid_ok,ind,nbors_grids_ok,iok)
 
            ! Store neighboring father grids for selected cells
            do j=1,twotondim
@@ -292,7 +288,7 @@ subroutine get3cubepos(ind_grid,ind,nbors_father_cells,ng)
   integer,dimension(1:threetondim),save::lll_loc,mmm_loc
 
   ! get the neighbor grids
-  call get_nbor_grids(ind_grid,ind,nbors_grids,ng)
+  call get_grids_of_nbor_cells(ind_grid,ind,nbors_grids,ng)
 
   ! fetch magic indices
   lll_loc = lll(:,ind)
@@ -317,34 +313,41 @@ end subroutine get3cubepos
 !##############################################################
 !##############################################################
 !##############################################################
-subroutine get_nbor_grids(ind_grid,ind,nbors_grids,ng)
+subroutine get_grids_of_nbor_cells(ind_grid,ind,nbors_grids,ng)
   use amr_commons
   implicit none
   integer,intent(in)::ng,ind
   integer,dimension(1:nvector),intent(in)::ind_grid
   integer,dimension(1:nvector,1:twotondim),intent(out)::nbors_grids
   !--------------------------------------------------------------------
-  ! This subroutine determines the two^ndim neighboring grids
-  ! of the input cell at position ind in grid ind_grid. 
+  ! This subroutine determines the two^ndim grids that contain the
+  ! 3x3x3 neighboring cells of a cell at position ind in the grid ind_grid.
   ! According to the refinements rules and since the input cell is refined,
   ! they should be present anytime.
   !
-  ! example 1D:
+  ! example in 1D:
   !
-  !   input:            || IND_GRID ||
-  !                       containing
-  !              ||  cell=ind  | another cell ||
+  !   input:     ||       IND_GRID        ||
+  !              || cell=IND | other cell ||
   !
-  !   ind_grid is itself a cell at ilevel-1:
-  !                            || father grid ||
-  !                     || father cell | another cell ||
-  !                     ||  IND_GRID  || another grid ||
+  !   for IND_GRID we have access to the father cell (through father(grid))
+  !   and the neighboring cells of the father cell (through nbor(grid,:)):
+  !  
+  !      || another cell | neighbor f. cell || father cell | neighbor f. cell ||
+  !                                         ||  IND_GRID  ||
   !
-  !   ind_grid has 2 neighbor grids:
-  !    || neighbor grid ||  IND_GRID  || neighbor grid ||
+  !   For those neighbor cells, we can get the child grid (through son(neighbor_cell)):
   !
-  ! TC: I don't see how ind matters here??
-  ! TC maybe my drawing isn't right
+  !      || another cell | neighbor f. cell || father cell | neighbor f. cell ||
+  !                     || son grid of nbor ||  IND_GRID  || son grid of nbor ||
+  ! 
+  !   We need only the grids which contain the neighbor cells. This will be ind_grid
+  !   itself and either its left or right neighbor:
+  !
+  !                     || SON GRID OF NBOR ||  IND_GRID  || son grid of nbor ||
+  !                     ||  cell   | nbor   || ind  | nbor||  cell  |   cell  ||
+  ! 
+  ! so the output in this case is the left and middle grid (in capital letters).
   !--------------------------------------------------------------------
   integer::i,inbor
   integer::ii,iimin,iimax
@@ -395,7 +398,6 @@ subroutine get_nbor_grids(ind_grid,ind,nbors_grids,ng)
               inbor=iii(ind)
               do i=1,ng
                  if(ind_grid2(i)>0)then
-                    ! TC: I don't really get this son(nbor) thing. What does son and nbor really contain?
                     ind_grid3(i)=son(nbor(ind_grid2(i),inbor))
                  endif
               end do
@@ -410,7 +412,7 @@ subroutine get_nbor_grids(ind_grid,ind,nbors_grids,ng)
      end do
   end do
 
-end subroutine get_nbor_grids
+end subroutine get_grids_of_nbor_cells
 !##############################################################
 !##############################################################
 !##############################################################
@@ -461,7 +463,7 @@ subroutine getnborfather(ind_cell,ind_father,ncell,ilevel)
   integer,dimension(1:nvector,0:twondim)::ind_father
   !-----------------------------------------------------------------
   ! This subroutine determines the 2*ndim neighboring cells
-  ! cells of the input cell (ind_cell).
+  ! of the input cell (ind_cell).
   ! If for some reasons they don't exist, the routine returns
   ! the neighboring father cells of the input cell.
   !-----------------------------------------------------------------
@@ -584,8 +586,9 @@ subroutine getnborgrids(igrid,igridn,ngrid)
   ! grids for grid igrid(:). The index for the central
   ! grid is stored in igridn(:,0). If for some reasons
   ! the neighboring grids don't exist, then igridn(:,j) = 0.
-  ! TC: =0 is not guaranteed?
-  ! TC: is it needed to store igrid?
+  ! TC: =0 is not guaranteed? Yes it is because son is 0
+  ! if son if 0 then its a leaf cell
+  ! TC: is it needed to store igrid? yes for loop?
   !---------------------------------------------------------
   integer::i,j
 
@@ -596,6 +599,9 @@ subroutine getnborgrids(igrid,igridn,ngrid)
   ! Store neighboring grids
   do j=1,twondim
      do i=1,ngrid
+        ! nbor(igrid(i),j) is the jth neighbor cell of the father cell
+        ! of the grid with index igrid
+        ! Son points to the child grid of that cell.
         igridn(i,j)=son(nbor(igrid(i),j))
      end do
   end do

--- a/amr/nbors_utils.f90
+++ b/amr/nbors_utils.f90
@@ -456,7 +456,7 @@ subroutine getnborfather(ind_cell,ind_father,ncell,ilevel)
   integer,dimension(1:3)::ibound,iskip1,iskip2
   integer,dimension(1:nvector,1:3),save::ix
   integer,dimension(1:nvector),save::ind_grid_father,pos
-  integer,dimension(1:nvector,0:twondim),save::igridn,igridn_ok
+  integer,dimension(1:nvector,0:twondim),save::igridn,igridn_ok,icell_ok
   integer,dimension(1:nvector,1:twondim),save::icelln_ok
 
   nxny=nx*ny
@@ -535,27 +535,26 @@ subroutine getnborfather(ind_cell,ind_father,ncell,ilevel)
               if(pos(i)==ind)then
                  iok=iok+1
                  igridn_ok(iok,j)=igridn(i,j)
+                 icell_ok(iok,j)=i
               end if
            end do
         end do
 
         ! Get neighboring cells for selected cells
-        if(iok>0)call getnborcells(igridn_ok,ind,icelln_ok,iok)
+        if(iok>0) then
+           call getnborcells(igridn_ok,ind,icelln_ok,iok)
 
-        ! Update neighboring father cells for selected cells
-        do j=1,twondim
-           iok=0
-           do i=1,ncell
-              if(pos(i)==ind)then
-                 iok=iok+1
-                 if(icelln_ok(iok,j)>0)then
-                    ind_father(i,j)=icelln_ok(iok,j)
+           ! Update neighboring father cells for selected cells
+           do j=1,twondim
+              do i=1,iok
+                 if(icelln_ok(i,j)>0)then
+                    ind_father(icell_ok(i,j),j)=icelln_ok(i,j)
                  else
-                    ind_father(i,j)=nbor(ind_grid_father(i),j)
+                    ind_father(icell_ok(i,j),j)=nbor(ind_grid_father(icell_ok(i,j)),j)
                  end if
-              end if
+              end do
            end do
-        end do
+        end if
 
      end do
 

--- a/amr/nbors_utils.f90
+++ b/amr/nbors_utils.f90
@@ -295,8 +295,8 @@ subroutine get3cubepos(ind_grid,ind,nbors_father_cells,ng)
   mmm_loc = mmm(:,ind)
 
   do j=1,threetondim
-     igrid=lll(j,ind,ndim)
-     icell=mmm(j,ind,ndim)
+     igrid=lll_loc(j)
+     icell=mmm_loc(j)
      iskip=ncoarse+(icell-1)*ngridmax
      do i=1,ng
         nbors_father_cells(i,j) = merge(iskip+nbors_grids(i,igrid),0,(nbors_grids(i,igrid)>0))

--- a/amr/nbors_utils.f90
+++ b/amr/nbors_utils.f90
@@ -24,7 +24,7 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,ncell,ilevel)
   nxny=nx*ny
 
   if(ilevel==1)then  ! Easy...
-
+     if(myid==1)write(*,*)'NCELL',ncell
      do i=1,ncell
         iz(i)=(ind_cell_father(i)-1)/nxny
         iy(i)=(ind_cell_father(i)-1-iz(i)*nxny)/nx
@@ -43,8 +43,10 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,ncell,ilevel)
         if(ndim > 2)then
            do i=1,ncell
               iiz(i)=iz(i)+k1-1
-              if(iiz(i) < 0   )iiz(i)=nz-1
-              if(iiz(i) > nz-1)iiz(i)=0
+              iiz(i)=merge(nz-1, iiz(i), (iiz(i) < 0))
+              iiz(i)=merge(   0, iiz(i), (iiz(i) > nz-1))
+              !if(iiz(i) < 0   )iiz(i)=nz-1
+              !if(iiz(i) > nz-1)iiz(i)=0
            end do
         end if
         do j1=j1min,j1max
@@ -52,8 +54,10 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,ncell,ilevel)
            if(ndim > 1)then
               do i=1,ncell
                  iiy(i)=iy(i)+j1-1
-                 if(iiy(i) < 0   )iiy(i)=ny-1
-                 if(iiy(i) > ny-1)iiy(i)=0
+                 iiy(i)=merge(ny-1, iiy(i), (iiy(i) < 0))
+                 iiy(i)=merge(   0, iiy(i), (iiy(i) > ny-1))
+                 !if(iiy(i) < 0   )iiy(i)=ny-1
+                 !if(iiy(i) > ny-1)iiy(i)=0
               end do
            end if
            do i1=i1min,i1max
@@ -61,8 +65,10 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,ncell,ilevel)
               if(ndim > 0)then
                  do i=1,ncell
                     iix(i)=ix(i)+i1-1
-                    if(iix(i) < 0   )iix(i)=nx-1
-                    if(iix(i) > nx-1)iix(i)=0
+                    iix(i)=merge(nx-1, iix(i), (iix(i) < 0))
+                    iix(i)=merge(   0, iix(i), (iix(i) > nx-1))
+                    !if(iix(i) < 0   )iix(i)=nx-1
+                    !if(iix(i) > nx-1)iix(i)=0
                  end do
               end if
               ind_father=1+i1+3*j1+9*k1
@@ -133,7 +139,7 @@ subroutine get3cubefather_grids(ind_cell_father,nbors_father_grids,ncell,ilevel)
   !
   !           ||           father grid             || the other neighbor father grid ||
   !           || neighbor cell |  IND CELL FATHER  || neighbor cell  | neighbor cell ||
-  !
+  ! TC: not sure this is correct
   !------------------------------------------------------------------
   integer::i,j,nxny,i1,j1,k1,ind,iok
   integer::i1min,i1max,j1min,j1max,k1min,k1max,ind_father
@@ -163,8 +169,10 @@ subroutine get3cubefather_grids(ind_cell_father,nbors_father_grids,ncell,ilevel)
         if(ndim > 2)then
            do i=1,ncell
               iiz(i)=iz(i)+2*k1-1
-              if(iiz(i) < 0   )iiz(i)=nz-1
-              if(iiz(i) > nz-1)iiz(i)=0
+              iiz(i)=merge(nz-1, iiz(i), (iiz(i) < 0))
+              iiz(i)=merge(   0, iiz(i), (iiz(i) > nz-1))
+              !if(iiz(i) < 0   )iiz(i)=nz-1
+              !if(iiz(i) > nz-1)iiz(i)=0
            end do
         end if
         do j1=j1min,j1max
@@ -172,8 +180,10 @@ subroutine get3cubefather_grids(ind_cell_father,nbors_father_grids,ncell,ilevel)
            if(ndim > 1)then
               do i=1,ncell
                  iiy(i)=iy(i)+2*j1-1
-                 if(iiy(i) < 0   )iiy(i)=ny-1
-                 if(iiy(i) > ny-1)iiy(i)=0
+                 iiy(i)=merge(ny-1, iiy(i), (iiy(i) < 0))
+                 iiy(i)=merge(   0, iiy(i), (iiy(i) > ny-1))
+                 !if(iiy(i) < 0   )iiy(i)=ny-1
+                 !if(iiy(i) > ny-1)iiy(i)=0
               end do
            end if
            do i1=i1min,i1max
@@ -181,8 +191,10 @@ subroutine get3cubefather_grids(ind_cell_father,nbors_father_grids,ncell,ilevel)
               if(ndim > 0)then
                  do i=1,ncell
                     iix(i)=ix(i)+2*i1-1
-                    if(iix(i) < 0   )iix(i)=nx-1
-                    if(iix(i) > nx-1)iix(i)=0
+                    iix(i)=merge(nx-1, iix(i), (iix(i) < 0))
+                    iix(i)=merge(   0, iix(i), (iix(i) > nx-1))
+                    !if(iix(i) < 0   )iix(i)=nx-1
+                    !if(iix(i) > nx-1)iix(i)=0
                  end do
               end if
               ind_father=1+i1+2*j1+4*k1
@@ -291,12 +303,12 @@ subroutine get3cubepos(ind_grid,ind,nbors_father_cells,ng)
      icell=mmm(j,ind,ndim)
      iskip=ncoarse+(icell-1)*ngridmax
      do i=1,ng
-        !nbors_father_cells(i,j) = merge(iskip+nbors_grids(i,igrid),0,(nbors_grids(i,igrid)>0))
-        if(nbors_grids(i,igrid)>0)then
-           nbors_father_cells(i,j)=iskip+nbors_grids(i,igrid)
-        else
-           nbors_father_cells(i,j)=0
-        endif
+        nbors_father_cells(i,j) = merge(iskip+nbors_grids(i,igrid),0,(nbors_grids(i,igrid)>0))
+        !if(nbors_grids(i,igrid)>0)then
+        !   nbors_father_cells(i,j)=iskip+nbors_grids(i,igrid)
+        !else
+        !   nbors_father_cells(i,j)=0
+        !endif
      end do
   end do
 
@@ -419,7 +431,7 @@ subroutine getnborcells(igridn,ind,icelln,ng)
   integer::i,in,ig,ih,iskip,inbor,idim
 
   ! Reset indices
-  icelln(1:ng,1:twondim)=0
+  !icelln(1:ng,1:twondim)=0
   ! Compute cell numbers
   do inbor=1,2
      do idim=1,ndim
@@ -428,9 +440,10 @@ subroutine getnborcells(igridn,ind,icelln,ng)
         ih=jjj(idim,inbor,ind)
         iskip=ncoarse+(ih-1)*ngridmax
         do i=1,ng
-           if(igridn(i,ig)>0)then
-              icelln(i,in)=iskip+igridn(i,ig)
-           end if
+           icelln(i,in)=merge(iskip+igridn(i,ig), 0, (igridn(i,ig)>0))
+           !if(igridn(i,ig)>0)then
+           !   icelln(i,in)=iskip+igridn(i,ig)
+           !end if
         end do
      enddo
   end do
@@ -480,45 +493,37 @@ subroutine getnborfather(ind_cell,ind_father,ncell,ilevel)
 
      do i=1,ncell
         ix(i,3)=(ind_father(i,0)-1)/nxny
-     end do
-     do i=1,ncell
         ix(i,2)=(ind_father(i,0)-1-ix(i,3)*nxny)/nx
-     end do
-     do i=1,ncell
         ix(i,1)=(ind_father(i,0)-1-ix(i,2)*nx-ix(i,3)*nxny)
      end do
 
      do idim=1,ndim
         do i=1,ncell
-           if(ix(i,idim)>0)then
-              ind_father(i,2*idim-1)=ind_father(i,0)-iskip1(idim)
-           else
-              ind_father(i,2*idim-1)=ind_father(i,0)+iskip2(idim)
-           end if
-        end do
-        do i=1,ncell
-           if(ix(i,idim)<ibound(idim))then
-              ind_father(i,2*idim)=ind_father(i,0)+iskip1(idim)
-           else
-              ind_father(i,2*idim)=ind_father(i,0)-iskip2(idim)
-           end if
+           ind_father(i,2*idim-1)=merge(ind_father(i,0)-iskip1(idim), ind_father(i,0)+iskip2(idim), (ix(i,idim)>0))
+           !if(ix(i,idim)>0)then
+           !   ind_father(i,2*idim-1)=ind_father(i,0)-iskip1(idim)
+           !else
+           !   ind_father(i,2*idim-1)=ind_father(i,0)+iskip2(idim)
+           !end if
+        !end do
+        !do i=1,ncell
+           ind_father(i,2*idim)=merge(ind_father(i,0)+iskip1(idim), ind_father(i,0)-iskip2(idim), (ix(i,idim)<ibound(idim)))
+           !if(ix(i,idim)<ibound(idim))then
+           !   ind_father(i,2*idim)=ind_father(i,0)+iskip1(idim)
+           !else
+           !   ind_father(i,2*idim)=ind_father(i,0)-iskip2(idim)
+           !end if
         end do
      end do
 
   else
 
-     ! Get father cell
      do i=1,ncell
+        ! Get father cell
         ind_father(i,0)=ind_cell(i)
-     end do
-
-     ! Get father cell position in the grid
-     do i=1,ncell
+        ! Get father cell position in the grid
         pos(i)=(ind_father(i,0)-ncoarse-1)/ngridmax+1
-     end do
-
-     ! Get father grid
-     do i=1,ncell
+        ! Get father grid
         ind_grid_father(i)=ind_father(i,0)-ncoarse-(pos(i)-1)*ngridmax
      end do
 
@@ -547,11 +552,14 @@ subroutine getnborfather(ind_cell,ind_father,ncell,ilevel)
            ! Update neighboring father cells for selected cells
            do j=1,twondim
               do i=1,iok
-                 if(icelln_ok(i,j)>0)then
-                    ind_father(icell_ok(i,j),j)=icelln_ok(i,j)
-                 else
-                    ind_father(icell_ok(i,j),j)=nbor(ind_grid_father(icell_ok(i,j)),j)
-                 end if
+                 ind_father(icell_ok(i,j),j)=merge(icelln_ok(i,j), &
+                                                 & nbor(ind_grid_father(icell_ok(i,j)),j), &
+                                                 &(icelln_ok(i,j)>0))
+                 !if(icelln_ok(i,j)>0)then
+                 !   ind_father(icell_ok(i,j),j)=icelln_ok(i,j)
+                 !else
+                 !   ind_father(icell_ok(i,j),j)=nbor(ind_grid_father(icell_ok(i,j)),j)
+                 !end if
               end do
            end do
         end if

--- a/amr/nbors_utils.f90
+++ b/amr/nbors_utils.f90
@@ -247,17 +247,16 @@ end subroutine get3cubefather_grids
 !##############################################################
 !##############################################################
 !##############################################################
-subroutine get3cubepos(ind_grid,ind,nbors_father_cells,ng)
+subroutine get3cubepos(ind_grid,ind,nbors_cells,ng)
   use amr_commons
   use amr_constants, only:lll,mmm
   implicit none
-  integer::ng,ind
-  integer,dimension(1:nvector)::ind_grid
-  integer,dimension(1:nvector,1:threetondim)::nbors_father_cells
+  integer,intent(in)::ng,ind
+  integer,dimension(1:nvector),intent(in)::ind_grid
+  integer,dimension(1:nvector,1:threetondim)::nbors_cells
   !--------------------------------------------------------------------
-  ! This subroutine determines the 3^ndim neighboring father cells
-  ! of the input cell at position ind in grid ind_grid. 
-  ! For this, first the two neighboring grids of ind_grid are determined.
+  ! This subroutine determines the 3^ndim neighboring cells
+  ! of the input cell at position ind in grid ind_grid.
   ! According to the refinements rules and since the input cell is refined,
   ! they should be present anytime.
   !
@@ -267,44 +266,39 @@ subroutine get3cubepos(ind_grid,ind,nbors_father_cells,ng)
   !                       containing
   !              ||  cell=ind  | another cell ||
   !
-  !   ind_grid is itself a cell at ilevel-1:
-  !                            || father grid ||
-  !                     || father cell | another cell ||
-  !                     ||  IND_GRID  || another grid ||
+  !   First, the grids of that contain the neighbors are determined by
+  !   the subroutine get_grids_of_nbor_cells:
   !
-  !   ind_grid has 2 neighbor grids:
-  !    || neighbor grid ||  IND_GRID  || neighbor grid ||
+  !     ||   NBOR GRID   ||    IND_GRID   || 
+  !     || cell |  nbor  ||  IND  |  nbor ||
   !
-  !   so there are 3 neighbor father cells in total for the cell ind in grid ind_grid:
-  !
-  !       level i-1   || another cell | nbor fath cell || nbor fath cell | nbor fath cell ||
-  !       level i                     || neighbor grid ||    IND_GRID    || neighbor grid ||
-  !
-  ! TC: I don't see how ind matters here??
   !--------------------------------------------------------------------
   integer::i,j,iskip
   integer::icell,igrid
   integer,dimension(1:nvector,1:twotondim),save::nbors_grids
   integer,dimension(1:threetondim),save::lll_loc,mmm_loc
 
-  ! get the neighbor grids
+  ! Get the grids that contain all neighbor cells
   call get_grids_of_nbor_cells(ind_grid,ind,nbors_grids,ng)
 
-  ! fetch magic indices
+  ! Fetch magic indices
   lll_loc = lll(:,ind)
   mmm_loc = mmm(:,ind)
 
+  ! Loop over 3x3x3 neighbor cells
   do j=1,threetondim
+     ! index in the list of nbor_grids of the grid in which the j-th neighbor cell should be located
      igrid=lll_loc(j)
+     ! position in which the neighbor cell should be located in its grid
      icell=mmm_loc(j)
      iskip=ncoarse+(icell-1)*ngridmax
      do i=1,ng
-        nbors_father_cells(i,j) = merge(iskip+nbors_grids(i,igrid),0,(nbors_grids(i,igrid)>0))
-        !if(nbors_grids(i,igrid)>0)then
-        !   nbors_father_cells(i,j)=iskip+nbors_grids(i,igrid)
-        !else
-        !   nbors_father_cells(i,j)=0
-        !endif
+        ! If the grid for neighbor cell j exists,
+        ! determine its index based on the index of the grid in which is sits
+        ! otherwise set 0.
+        nbors_cells(i,j) = merge(iskip+nbors_grids(i,igrid), & ! if-part
+                              &                           0, & ! else-part
+                              & (nbors_grids(i,igrid)>0))      ! condition
      end do
   end do
 

--- a/amr/nbors_utils.f90
+++ b/amr/nbors_utils.f90
@@ -16,7 +16,7 @@
 !                    Helper for get3cubefather. Calls get_grids_of_nbor_cells.
 
 !   (*) get_grids_of_nbor_cells: IN: grid & ind, OUT: 2^ndim neighbor grids
-!                                Obtain the grids that contain the neighbor cells 
+!                                Obtain the grids that contain the neighbor cells
 !                                of a cell sitting at position ind in the input grid.
 !                                Helper for get3cubepos and get3cubefather_grids.
 !
@@ -27,7 +27,7 @@
 !                    Calls getnborgrids and getnborcells.
 !
 !   * getnborgrids: IN: grid, OUT: 2*ndim neighbor grids
-!                   Obtain the direct neighboring grids of a grid. 
+!                   Obtain the direct neighboring grids of a grid.
 !                   The result includes the grid itself at
 !                   position 0 in the array.
 !                   Often called before getnborcells.
@@ -54,7 +54,7 @@ subroutine get3cubefather(ind_cell,nbor_cells,ncell,ilevel)
   integer,dimension(1:nvector,1:threetondim),intent(out)::nbor_cells
   !------------------------------------------------------------------
   ! This subroutine determines the 3^ndim neighboring cells
-  ! of the input cell ind_cell. This includes diagonal neighbors and 
+  ! of the input cell ind_cell. This includes diagonal neighbors and
   ! the center input cell itself.
   ! For example in 3D, as output, nbor_cells contains the 3x3x3 cube
   ! of 27 cells around, and including, ind_cell.
@@ -69,7 +69,7 @@ subroutine get3cubefather(ind_cell,nbor_cells,ncell,ilevel)
 
   if(ilevel==1)then  ! Easy...
      ! ncell is always 1 in this case
-     ! (because currently only cubic domains are supported, meaning 
+     ! (because currently only cubic domains are supported, meaning
      ! there is only 1 root cell)
      do i=1,ncell
         iz(i)=(ind_cell(i)-1)/nxny
@@ -83,7 +83,7 @@ subroutine get3cubefather(ind_cell,nbor_cells,ncell,ilevel)
      k1min=0; k1max=0
      if(ndim > 2)k1max=2
 
-     ! Loop over 3^ndim neighboring cells by looking 
+     ! Loop over 3^ndim neighboring cells by looking
      ! left, center and right of the root cell
      do k1=k1min,k1max
         iiz=iz
@@ -266,10 +266,10 @@ subroutine get3cubepos(ind_grid,ind,nbors_cells,ng)
   !   The grids of that contain the neighbors are determined by
   !   the subroutine get_grids_of_nbor_cells:
   !
-  !     ||   NBOR GRID   ||    IND_GRID   || 
+  !     ||   NBOR GRID   ||    IND_GRID   ||
   !     || cell |  nbor  ||  IND  |  nbor ||
   !
-  !   Then, to extract the cells from the grids, we use the indices from 
+  !   Then, to extract the cells from the grids, we use the indices from
   !   lll and mmm
   !
   !--------------------------------------------------------------------
@@ -329,7 +329,7 @@ subroutine get_grids_of_nbor_cells(ind_grid,ind,nbors_grids,ng)
   !
   !   for IND_GRID we have access to the father cell (through father(grid))
   !   and the neighboring cells of the father cell (through nbor(grid,:)):
-  !  
+  !
   !      || another cell | neighbor f. cell || father cell | neighbor f. cell ||
   !                                         ||  IND_GRID  ||
   !
@@ -337,13 +337,13 @@ subroutine get_grids_of_nbor_cells(ind_grid,ind,nbors_grids,ng)
   !
   !      || another cell | neighbor f. cell || father cell | neighbor f. cell ||
   !                     || son grid of nbor ||  IND_GRID  || son grid of nbor ||
-  ! 
+  !
   !   We need only the grids which contain the neighbor cells. This will be ind_grid
   !   itself and either its left or right neighbor:
   !
   !                     || SON GRID OF NBOR ||  IND_GRID  || son grid of nbor ||
   !                     ||  cell   | nbor   || ind  | nbor||  cell  |   cell  ||
-  ! 
+  !
   !   In this example, the requested grids are the left and middle grid (in capital letters).
   !--------------------------------------------------------------------
   integer::i,inbor
@@ -430,7 +430,7 @@ subroutine getnborcells(igridn,ind,icelln,ng)
   ! Reset indices
   icelln(1:ng,1:twondim)=0
 
-  ! Extract, out of the input grids, the left and right 
+  ! Extract, out of the input grids, the left and right
   ! neighbor cell in each dimension.
   do inbor=1,2
      do idim=1,ndim
@@ -591,7 +591,7 @@ subroutine getnborgrids(igrid,igridn,ngrid)
   ! grid is stored in igridn(:,0).  We need it for when we want
   ! to later derive the neighbor cells from these grids (see
   ! getnborcells).
-  ! If for some reasons the neighboring grids don't exist, 
+  ! If for some reasons the neighboring grids don't exist,
   ! then igridn(:,j) = 0 (because son is 0, i.e. it's a leaf cell).
   !---------------------------------------------------------
   integer::i,j

--- a/amr/nbors_utils.f90
+++ b/amr/nbors_utils.f90
@@ -1,141 +1,25 @@
-subroutine get3cubefather_bis(ind_cell_father,nbors_father_cells,&
-   &                    ncell,ilevel)
-use amr_commons
-implicit none
-integer::ncell,ilevel
-integer,dimension(1:nvector)::ind_cell_father
-integer,dimension(1:nvector,1:threetondim)::nbors_father_cells
-!------------------------------------------------------------------
-! This subroutine determines the 3^ndim neighboring father cells
-! of the input father cell. According to the refinement rule,
-! they should be present anytime.
-!------------------------------------------------------------------
-integer::i,j,nxny,i1,j1,k1,ind,iok
-integer::i1min,i1max,j1min,j1max,k1min,k1max,ind_father
-integer,dimension(1:nvector),save::ix,iy,iz,iix,iiy,iiz
-integer,dimension(1:nvector),save::pos,ind_grid_father,ind_grid_ok,ind_cell_ok
-integer,dimension(1:nvector,1:threetondim),save::nbors_father_ok
-integer,dimension(1:nvector,1:twotondim),save::nbors_grids_ok
-logical::oups
-
-nxny=nx*ny
-
-if(ilevel==1)then  ! Easy...
-
-   do i=1,ncell
-      iz(i)=(ind_cell_father(i)-1)/nxny
-      iy(i)=(ind_cell_father(i)-1-iz(i)*nxny)/nx
-      ix(i)=(ind_cell_father(i)-1-iy(i)*nx-iz(i)*nxny)
-   end do
-
-   i1min=0; i1max=0
-   if(ndim > 0)i1max=2
-   j1min=0; j1max=0
-   if(ndim > 1)j1max=2
-   k1min=0; k1max=0
-   if(ndim > 2)k1max=2
-
-   ! Loop over 3^ndim neighboring father cells
-   do k1=k1min,k1max
-      iiz=iz
-      if(ndim > 2)then
-         do i=1,ncell
-            iiz(i)=iz(i)+k1-1
-            if(iiz(i) < 0   )iiz(i)=nz-1
-            if(iiz(i) > nz-1)iiz(i)=0
-         end do
-      end if
-      do j1=j1min,j1max
-         iiy=iy
-         if(ndim > 1)then
-            do i=1,ncell
-               iiy(i)=iy(i)+j1-1
-               if(iiy(i) < 0   )iiy(i)=ny-1
-               if(iiy(i) > ny-1)iiy(i)=0
-            end do
-         end if
-         do i1=i1min,i1max
-            iix=ix
-            if(ndim > 0)then
-               do i=1,ncell
-                  iix(i)=ix(i)+i1-1
-                  if(iix(i) < 0   )iix(i)=nx-1
-                  if(iix(i) > nx-1)iix(i)=0
-               end do
-            end if
-            ind_father=1+i1+3*j1+9*k1
-            do i=1,ncell
-               nbors_father_cells(i,ind_father)=1 &
-                    & +iix(i) &
-                    & +iiy(i)*nx &
-                    & +iiz(i)*nxny
-            end do
-         end do
-      end do
-   end do
-
-else    ! else, more complicated...
-
-   do i=1,ncell
-      ! Get father cell position in the grid
-      pos(i)=(ind_cell_father(i)-ncoarse-1)/ngridmax+1
-      ! Get father grid
-      ind_grid_father(i)=ind_cell_father(i)-ncoarse-(pos(i)-1)*ngridmax
-   end do
-
-   ! Loop over position
-   do ind=1,twotondim
-
-      ! Select father cells that sit at position ind
-      iok=0
-      do i=1,ncell
-         if(pos(i)==ind)then
-            iok=iok+1
-            ind_grid_ok(iok)=ind_grid_father(i)
-            ind_cell_ok(iok)=i
-         end if
-      end do
-
-      if(iok>0)then
-         call get3cubepos(ind_grid_ok,ind,nbors_father_ok,nbors_grids_ok,iok)
-
-         ! Store neighboring father cells for selected cells
-         do j=1,threetondim
-            do i=1,iok
-               nbors_father_cells(ind_cell_ok(i),j)=nbors_father_ok(i,j)
-            end do
-         end do
-      end if
-
-   end do
-
-end if
-
-end subroutine get3cubefather_bis
 !##############################################################
 !##############################################################
 !##############################################################
 !##############################################################
-subroutine get3cubefather(ind_cell_father,nbors_father_cells,&
-     &                    nbors_father_grids,ncell,ilevel)
+subroutine get3cubefather(ind_cell_father,nbors_father_cells,ncell,ilevel)
   use amr_commons
   implicit none
-  integer::ncell,ilevel
-  integer,dimension(1:nvector)::ind_cell_father
-  integer,dimension(1:nvector,1:threetondim)::nbors_father_cells
-  integer,dimension(1:nvector,1:twotondim)::nbors_father_grids
+  integer,intent(in)::ncell,ilevel
+  integer,dimension(1:nvector),intent(in)::ind_cell_father
+  integer,dimension(1:nvector,1:threetondim),intent(out)::nbors_father_cells
   !------------------------------------------------------------------
   ! This subroutine determines the 3^ndim neighboring father cells
   ! of the input father cell. According to the refinement rule,
   ! they should be present anytime.
+  ! For example in 3D, as output, nbors_father_cells contains the cube of 27 cells 
+  ! around, and including, ind_cell_father.
   !------------------------------------------------------------------
   integer::i,j,nxny,i1,j1,k1,ind,iok
   integer::i1min,i1max,j1min,j1max,k1min,k1max,ind_father
   integer,dimension(1:nvector),save::ix,iy,iz,iix,iiy,iiz
   integer,dimension(1:nvector),save::pos,ind_grid_father,ind_grid_ok,ind_cell_ok
   integer,dimension(1:nvector,1:threetondim),save::nbors_father_ok
-  integer,dimension(1:nvector,1:twotondim),save::nbors_grids_ok
-  logical::oups
 
   nxny=nx*ny
 
@@ -147,8 +31,7 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,&
         ix(i)=(ind_cell_father(i)-1-iy(i)*nx-iz(i)*nxny)
      end do
 
-     i1min=0; i1max=0
-     if(ndim > 0)i1max=2
+     i1min=0; i1max=2
      j1min=0; j1max=0
      if(ndim > 1)j1max=2
      k1min=0; k1max=0
@@ -193,6 +76,87 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,&
         end do
      end do
 
+  else    ! else, more complicated...
+
+     do i=1,ncell
+        ! Get father cell position in the grid
+        pos(i)=(ind_cell_father(i)-ncoarse-1)/ngridmax+1
+        ! Get father grid
+        ind_grid_father(i)=ind_cell_father(i)-ncoarse-(pos(i)-1)*ngridmax
+     end do
+
+     ! Loop over position
+     do ind=1,twotondim
+
+        ! Select father cells that sit at position ind
+        iok=0
+        do i=1,ncell
+           if(pos(i)==ind)then
+              iok=iok+1
+              ind_grid_ok(iok)=ind_grid_father(i)
+              ind_cell_ok(iok)=i
+           end if
+        end do
+
+        if(iok>0)then
+           call get3cubepos(ind_grid_ok,ind,nbors_father_ok,iok)
+
+           ! Store neighboring father cells for selected cells
+           do j=1,threetondim
+              do i=1,iok
+                 nbors_father_cells(ind_cell_ok(i),j)=nbors_father_ok(i,j)
+              end do
+           end do
+        end if
+
+     end do
+
+  end if
+
+end subroutine get3cubefather
+!##############################################################
+!##############################################################
+!##############################################################
+!##############################################################
+subroutine get3cubefather_grids(ind_cell_father,nbors_father_grids,ncell,ilevel)
+  use amr_commons
+  implicit none
+  integer,intent(in)::ncell,ilevel
+  integer,dimension(1:nvector),intent(in)::ind_cell_father
+  integer,dimension(1:nvector,1:twotondim),intent(out)::nbors_father_grids
+  !------------------------------------------------------------------
+  ! This subroutine determines the 2^ndim neighboring father grids
+  ! of the input father cell. According to the refinement rule,
+  ! they should be present anytime.
+  !
+  ! example 1D:
+  !
+  !           ||           father grid             || the other neighbor father grid ||
+  !           || neighbor cell |  IND CELL FATHER  || neighbor cell  | neighbor cell ||
+  !
+  !------------------------------------------------------------------
+  integer::i,j,nxny,i1,j1,k1,ind,iok
+  integer::i1min,i1max,j1min,j1max,k1min,k1max,ind_father
+  integer,dimension(1:nvector),save::ix,iy,iz,iix,iiy,iiz
+  integer,dimension(1:nvector),save::pos,ind_grid_father,ind_grid_ok,ind_cell_ok
+  integer,dimension(1:nvector,1:twotondim),save::nbors_grids_ok
+
+  nxny=nx*ny
+
+  if(ilevel==1)then  ! Easy...
+
+     do i=1,ncell
+        iz(i)=(ind_cell_father(i)-1)/nxny
+        iy(i)=(ind_cell_father(i)-1-iz(i)*nxny)/nx
+        ix(i)=(ind_cell_father(i)-1-iy(i)*nx-iz(i)*nxny)
+     end do
+
+     i1min=0; i1max=2
+     j1min=0; j1max=0
+     if(ndim > 1)j1max=2
+     k1min=0; k1max=0
+     if(ndim > 2)k1max=2
+
      ! Loop over 2^ndim neighboring father grids
      do k1=k1min,k1max
         iiz=iz
@@ -233,6 +197,7 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,&
      end do
 
   else    ! else, more complicated...
+     !TC: can this be simplified now?
 
      do i=1,ncell
         ! Get father cell position in the grid
@@ -255,14 +220,7 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,&
         end do
 
         if(iok>0)then
-           call get3cubepos(ind_grid_ok,ind,nbors_father_ok,nbors_grids_ok,iok)
-
-           ! Store neighboring father cells for selected cells
-           do j=1,threetondim
-              do i=1,iok
-                 nbors_father_cells(ind_cell_ok(i),j)=nbors_father_ok(i,j)
-              end do
-           end do
+           call get_nbor_grids(ind_grid_ok,ind,nbors_grids_ok,iok)
 
            ! Store neighboring father grids for selected cells
            do j=1,twotondim
@@ -276,19 +234,18 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,&
 
   end if
 
-end subroutine get3cubefather
+end subroutine get3cubefather_grids
 !##############################################################
 !##############################################################
 !##############################################################
 !##############################################################
-subroutine get3cubepos(ind_grid,ind,nbors_father_cells,nbors_father_grids,ng)
+subroutine get3cubepos(ind_grid,ind,nbors_father_cells,ng)
   use amr_commons
   use amr_constants, only:lll,mmm
   implicit none
   integer::ng,ind
   integer,dimension(1:nvector)::ind_grid
   integer,dimension(1:nvector,1:threetondim)::nbors_father_cells
-  integer,dimension(1:nvector,1:twotondim)::nbors_father_grids
   !--------------------------------------------------------------------
   ! This subroutine determines the 3^ndim neighboring father cells
   ! of the input cell at position ind in grid ind_grid. 
@@ -315,24 +272,78 @@ subroutine get3cubepos(ind_grid,ind,nbors_father_cells,nbors_father_grids,ng)
   !       level i-1   || another cell | nbor fath cell || nbor fath cell | nbor fath cell ||
   !       level i                     || neighbor grid ||    IND_GRID    || neighbor grid ||
   !
+  ! TC: I don't see how ind matters here??
   !--------------------------------------------------------------------
   integer::i,j,iskip
-  integer::ii,iimin,iimax
-  integer::jj,jjmin,jjmax
-  integer::kk,kkmin,kkmax
-  integer::icell,igrid,inbor
-  integer,dimension(1:8)::iii=(/1,2,1,2,1,2,1,2/)
-  integer,dimension(1:8)::jjj=(/3,3,4,4,3,3,4,4/)
-  integer,dimension(1:8)::kkk=(/5,5,5,5,6,6,6,6/)
-  integer,dimension(1:nvector),save::ind_grid1,ind_grid2,ind_grid3
+  integer::icell,igrid
+  integer,dimension(1:nvector,1:twotondim),save::nbors_grids
   integer,dimension(1:threetondim),save::lll_loc,mmm_loc
+
+  ! get the neighbor grids
+  call get_nbor_grids(ind_grid,ind,nbors_grids,ng)
 
   ! fetch magic indices
   lll_loc = lll(:,ind)
   mmm_loc = mmm(:,ind)
 
-  iimin=0; iimax=0
-  if(ndim>0)iimax=1
+  do j=1,threetondim
+     igrid=lll(j,ind,ndim)
+     icell=mmm(j,ind,ndim)
+     iskip=ncoarse+(icell-1)*ngridmax
+     do i=1,ng
+        !nbors_father_cells(i,j) = merge(iskip+nbors_grids(i,igrid),0,(nbors_grids(i,igrid)>0))
+        if(nbors_grids(i,igrid)>0)then
+           nbors_father_cells(i,j)=iskip+nbors_grids(i,igrid)
+        else
+           nbors_father_cells(i,j)=0
+        endif
+     end do
+  end do
+
+end subroutine get3cubepos
+!##############################################################
+!##############################################################
+!##############################################################
+!##############################################################
+subroutine get_nbor_grids(ind_grid,ind,nbors_grids,ng)
+  use amr_commons
+  implicit none
+  integer,intent(in)::ng,ind
+  integer,dimension(1:nvector),intent(in)::ind_grid
+  integer,dimension(1:nvector,1:twotondim),intent(out)::nbors_grids
+  !--------------------------------------------------------------------
+  ! This subroutine determines the two^ndim neighboring grids
+  ! of the input cell at position ind in grid ind_grid. 
+  ! According to the refinements rules and since the input cell is refined,
+  ! they should be present anytime.
+  !
+  ! example 1D:
+  !
+  !   input:            || IND_GRID ||
+  !                       containing
+  !              ||  cell=ind  | another cell ||
+  !
+  !   ind_grid is itself a cell at ilevel-1:
+  !                            || father grid ||
+  !                     || father cell | another cell ||
+  !                     ||  IND_GRID  || another grid ||
+  !
+  !   ind_grid has 2 neighbor grids:
+  !    || neighbor grid ||  IND_GRID  || neighbor grid ||
+  !
+  ! TC: I don't see how ind matters here??
+  ! TC maybe my drawing isn't right
+  !--------------------------------------------------------------------
+  integer::i,inbor
+  integer::ii,iimin,iimax
+  integer::jj,jjmin,jjmax
+  integer::kk,kkmin,kkmax
+  integer,dimension(1:8)::iii=(/1,2,1,2,1,2,1,2/)
+  integer,dimension(1:8)::jjj=(/3,3,4,4,3,3,4,4/)
+  integer,dimension(1:8)::kkk=(/5,5,5,5,6,6,6,6/)
+  integer,dimension(1:nvector),save::ind_grid1,ind_grid2,ind_grid3
+
+  iimin=0; iimax=1
   jjmin=0; jjmax=0
   if(ndim>1)jjmax=1
   kkmin=0; kkmax=0
@@ -372,6 +383,7 @@ subroutine get3cubepos(ind_grid,ind,nbors_father_cells,nbors_father_grids,ng)
               inbor=iii(ind)
               do i=1,ng
                  if(ind_grid2(i)>0)then
+                    ! TC: I don't really get this son(nbor) thing. What does son and nbor really contain?
                     ind_grid3(i)=son(nbor(ind_grid2(i),inbor))
                  endif
               end do
@@ -379,28 +391,14 @@ subroutine get3cubepos(ind_grid,ind,nbors_father_cells,nbors_father_grids,ng)
 
            inbor=1+ii+2*jj+4*kk
            do i=1,ng
-              nbors_father_grids(i,inbor)=ind_grid3(i)
+              nbors_grids(i,inbor)=ind_grid3(i)
            end do
 
         end do
      end do
   end do
 
-  do j=1,threetondim
-     igrid=lll_loc(j)
-     icell=mmm_loc(j)
-     iskip=ncoarse+(icell-1)*ngridmax
-     do i=1,ng
-        !nbors_father_cells(i,j) = merge(iskip+nbors_father_grids(i,igrid),0,(nbors_father_grids(i,igrid)>0))
-        if(nbors_father_grids(i,igrid)>0)then
-           nbors_father_cells(i,j)=iskip+nbors_father_grids(i,igrid)
-        else
-           nbors_father_cells(i,j)=0
-        endif
-     end do
-  end do
-
-end subroutine get3cubepos
+end subroutine get_nbor_grids
 !##############################################################
 !##############################################################
 !##############################################################
@@ -571,14 +569,16 @@ end subroutine getnborfather
 subroutine getnborgrids(igrid,igridn,ngrid)
   use amr_commons
   implicit none
-  integer::ngrid
-  integer,dimension(1:nvector)::igrid
-  integer,dimension(1:nvector,0:twondim)::igridn
+  integer,intent(in)::ngrid
+  integer,dimension(1:nvector),intent(in)::igrid
+  integer,dimension(1:nvector,0:twondim),intent(out)::igridn
   !---------------------------------------------------------
-  ! This routine computes the index of the 6 neighboring
+  ! This routine computes the index of the 2 x ndim neighboring
   ! grids for grid igrid(:). The index for the central
   ! grid is stored in igridn(:,0). If for some reasons
   ! the neighboring grids don't exist, then igridn(:,j) = 0.
+  ! TC: =0 is not guaranteed?
+  ! TC: is it needed to store igrid?
   !---------------------------------------------------------
   integer::i,j
 
@@ -608,6 +608,7 @@ subroutine getnborgrids_check(igrid,igridn,ngrid)
   ! This routine does EXACTLY the same as getnborgrids
   ! but it checks if the neighbor of igrid exists in order
   ! to avoid son(0) leading to crash.
+  ! TC: doesn't this possibly result in a garbage value for igridn where son was 0? 
   !---------------------------------------------------------
   integer::i,j
 

--- a/amr/nbors_utils.f90
+++ b/amr/nbors_utils.f90
@@ -13,7 +13,7 @@ integer,dimension(1:nvector,1:threetondim)::nbors_father_cells
 integer::i,j,nxny,i1,j1,k1,ind,iok
 integer::i1min,i1max,j1min,j1max,k1min,k1max,ind_father
 integer,dimension(1:nvector),save::ix,iy,iz,iix,iiy,iiz
-integer,dimension(1:nvector),save::pos,ind_grid_father,ind_grid_ok
+integer,dimension(1:nvector),save::pos,ind_grid_father,ind_grid_ok,ind_cell_ok
 integer,dimension(1:nvector,1:threetondim),save::nbors_father_ok
 logical::oups
 
@@ -91,23 +91,20 @@ else    ! else, more complicated...
          if(pos(i)==ind)then
             iok=iok+1
             ind_grid_ok(iok)=ind_grid_father(i)
+            ind_cell_ok(iok)=i
          end if
       end do
 
       if(iok>0)then
          call get3cubepos_bis(ind_grid_ok,ind,nbors_father_ok,iok)
-      endif
 
-      ! Store neighboring father cells for selected cells
-      do j=1,threetondim
-         iok=0
-         do i=1,ncell
-            if(pos(i)==ind)then
-               iok=iok+1
-               nbors_father_cells(i,j)=nbors_father_ok(iok,j)
-            end if
+         ! Store neighboring father cells for selected cells
+         do j=1,threetondim
+            do i=1,iok
+               nbors_father_cells(ind_cell_ok(i),j)=nbors_father_ok(i,j)
+            end do
          end do
-      end do
+      end if
 
    end do
 
@@ -134,7 +131,7 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,&
   integer::i,j,nxny,i1,j1,k1,ind,iok
   integer::i1min,i1max,j1min,j1max,k1min,k1max,ind_father
   integer,dimension(1:nvector),save::ix,iy,iz,iix,iiy,iiz
-  integer,dimension(1:nvector),save::pos,ind_grid_father,ind_grid_ok
+  integer,dimension(1:nvector),save::pos,ind_grid_father,ind_grid_ok,ind_cell_ok
   integer,dimension(1:nvector,1:threetondim),save::nbors_father_ok
   integer,dimension(1:nvector,1:twotondim),save::nbors_grids_ok
   logical::oups
@@ -142,16 +139,6 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,&
   nxny=nx*ny
 
   if(ilevel==1)then  ! Easy...
-
-     oups=.false.
-     do i=1,ncell
-        if(ind_cell_father(i)>ncoarse)oups=.true.
-     end do
-     if(oups)then
-        write(*,*)'get3cubefather'
-        write(*,*)'oupsssss !'
-        call clean_stop
-     endif
 
      do i=1,ncell
         iz(i)=(ind_cell_father(i)-1)/nxny
@@ -262,34 +249,27 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,&
            if(pos(i)==ind)then
               iok=iok+1
               ind_grid_ok(iok)=ind_grid_father(i)
+              ind_cell_ok(iok)=i
            end if
         end do
 
         if(iok>0)then
            call get3cubepos(ind_grid_ok,ind,nbors_father_ok,nbors_grids_ok,iok)
+
+           ! Store neighboring father cells for selected cells
+           do j=1,threetondim
+              do i=1,iok
+                 nbors_father_cells(ind_cell_ok(i),j)=nbors_father_ok(i,j)
+              end do
+           end do
+
+           ! Store neighboring father grids for selected cells
+           do j=1,twotondim
+              do i=1,iok
+                 nbors_father_grids(ind_cell_ok(i),j)=nbors_grids_ok(i,j)
+              end do
+           end do
         endif
-
-        ! Store neighboring father cells for selected cells
-        do j=1,threetondim
-           iok=0
-           do i=1,ncell
-              if(pos(i)==ind)then
-                 iok=iok+1
-                 nbors_father_cells(i,j)=nbors_father_ok(iok,j)
-              end if
-           end do
-        end do
-
-        ! Store neighboring father grids for selected cells
-        do j=1,twotondim
-           iok=0
-           do i=1,ncell
-              if(pos(i)==ind)then
-                 iok=iok+1
-                 nbors_father_grids(i,j)=nbors_grids_ok(iok,j)
-              end if
-           end do
-        end do
 
      end do
 

--- a/amr/nbors_utils.f90
+++ b/amr/nbors_utils.f90
@@ -15,6 +15,7 @@ integer::i1min,i1max,j1min,j1max,k1min,k1max,ind_father
 integer,dimension(1:nvector),save::ix,iy,iz,iix,iiy,iiz
 integer,dimension(1:nvector),save::pos,ind_grid_father,ind_grid_ok,ind_cell_ok
 integer,dimension(1:nvector,1:threetondim),save::nbors_father_ok
+integer,dimension(1:nvector,1:twotondim),save::nbors_grids_ok
 logical::oups
 
 nxny=nx*ny
@@ -96,7 +97,7 @@ else    ! else, more complicated...
       end do
 
       if(iok>0)then
-         call get3cubepos_bis(ind_grid_ok,ind,nbors_father_ok,iok)
+         call get3cubepos(ind_grid_ok,ind,nbors_father_ok,nbors_grids_ok,iok)
 
          ! Store neighboring father cells for selected cells
          do j=1,threetondim
@@ -280,106 +281,6 @@ end subroutine get3cubefather
 !##############################################################
 !##############################################################
 !##############################################################
-subroutine get3cubepos_bis(ind_grid,ind,nbors_father_cells,ng)
-  use amr_commons
-  implicit none
-  integer::ng,ind
-  integer,dimension(1:nvector)::ind_grid
-  integer,dimension(1:nvector,1:threetondim)::nbors_father_cells
-  !--------------------------------------------------------------------
-  ! This subroutine determines the 3^ndim neighboring father cells
-  ! of the input cell at position ind in grid ind_grid. According to
-  ! the refinements rules and since the input cell is refined,
-  ! they should be present anytime.
-  !--------------------------------------------------------------------
-  integer::i,j,iskip
-  integer::ii,iimin,iimax
-  integer::jj,jjmin,jjmax
-  integer::kk,kkmin,kkmax
-  integer::icell,igrid,inbor
-  integer,dimension(1:8)::iii=(/1,2,1,2,1,2,1,2/)
-  integer,dimension(1:8)::jjj=(/3,3,4,4,3,3,4,4/)
-  integer,dimension(1:8)::kkk=(/5,5,5,5,6,6,6,6/)
-  integer,dimension(1:27,1:8,1:3)::lll,mmm
-  integer,dimension(1:nvector),save::ind_grid1,ind_grid2,ind_grid3
-  integer,dimension(1:nvector,1:twotondim),save::nbors_grids
-
-  call getindices3cube(lll,mmm)
-
-  iimin=0; iimax=0
-  if(ndim>0)iimax=1
-  jjmin=0; jjmax=0
-  if(ndim>1)jjmax=1
-  kkmin=0; kkmax=0
-  if(ndim>2)kkmax=1
-
-  do kk=kkmin,kkmax
-     do i=1,ng
-        ind_grid1(i)=ind_grid(i)
-     end do
-     if(kk>0)then
-        inbor=kkk(ind)
-        do i=1,ng
-           if(ind_grid(i)>0)then
-              ind_grid1(i)=son(nbor(ind_grid(i),inbor))
-           endif
-        end do
-     end if
-
-     do jj=jjmin,jjmax
-        do i=1,ng
-           ind_grid2(i)=ind_grid1(i)
-        end do
-        if(jj>0)then
-           inbor=jjj(ind)
-           do i=1,ng
-              if(ind_grid1(i)>0)then
-                 ind_grid2(i)=son(nbor(ind_grid1(i),inbor))
-              endif
-           end do
-        end if
-
-        do ii=iimin,iimax
-           do i=1,ng
-              ind_grid3(i)=ind_grid2(i)
-           end do
-           if(ii>0)then
-              inbor=iii(ind)
-              do i=1,ng
-                 if(ind_grid2(i)>0)then
-                    ind_grid3(i)=son(nbor(ind_grid2(i),inbor))
-                 endif
-              end do
-           end if
-
-           inbor=1+ii+2*jj+4*kk
-           do i=1,ng
-              nbors_grids(i,inbor)=ind_grid3(i)
-           end do
-
-        end do
-     end do
-  end do
-
-  do j=1,threetondim
-     igrid=lll(j,ind,ndim)
-     icell=mmm(j,ind,ndim)
-     iskip=ncoarse+(icell-1)*ngridmax
-     do i=1,ng
-        nbors_father_cells(i,j) = merge(iskip+nbors_grids(i,igrid),0,(nbors_grids(i,igrid)>0))
-        !if(nbors_grids(i,igrid)>0)then
-        !   nbors_father_cells(i,j)=iskip+nbors_grids(i,igrid)
-        !else
-        !   nbors_father_cells(i,j)=0
-        !endif
-     end do
-  end do
-
-end subroutine get3cubepos_bis
-!##############################################################
-!##############################################################
-!##############################################################
-!##############################################################
 subroutine get3cubepos(ind_grid,ind,nbors_father_cells,nbors_father_grids,ng)
   use amr_commons
   use amr_constants, only:lll,mmm
@@ -390,9 +291,30 @@ subroutine get3cubepos(ind_grid,ind,nbors_father_cells,nbors_father_grids,ng)
   integer,dimension(1:nvector,1:twotondim)::nbors_father_grids
   !--------------------------------------------------------------------
   ! This subroutine determines the 3^ndim neighboring father cells
-  ! of the input cell at position ind in grid ind_grid. According to
-  ! the refinements rules and since the input cell is refined,
+  ! of the input cell at position ind in grid ind_grid. 
+  ! For this, first the two neighboring grids of ind_grid are determined.
+  ! According to the refinements rules and since the input cell is refined,
   ! they should be present anytime.
+  !
+  ! example 1D:
+  !
+  !   input:            || IND_GRID ||
+  !                       containing
+  !              ||  cell=ind  | another cell ||
+  !
+  !   ind_grid is itself a cell at ilevel-1:
+  !                            || father grid ||
+  !                     || father cell | another cell ||
+  !                     ||  IND_GRID  || another grid ||
+  !
+  !   ind_grid has 2 neighbor grids:
+  !    || neighbor grid ||  IND_GRID  || neighbor grid ||
+  !
+  !   so there are 3 neighbor father cells in total for the cell ind in grid ind_grid:
+  !
+  !       level i-1   || another cell | nbor fath cell || nbor fath cell | nbor fath cell ||
+  !       level i                     || neighbor grid ||    IND_GRID    || neighbor grid ||
+  !
   !--------------------------------------------------------------------
   integer::i,j,iskip
   integer::ii,iimin,iimax
@@ -403,7 +325,6 @@ subroutine get3cubepos(ind_grid,ind,nbors_father_cells,nbors_father_grids,ng)
   integer,dimension(1:8)::jjj=(/3,3,4,4,3,3,4,4/)
   integer,dimension(1:8)::kkk=(/5,5,5,5,6,6,6,6/)
   integer,dimension(1:nvector),save::ind_grid1,ind_grid2,ind_grid3
-  integer,dimension(1:nvector,1:twotondim),save::nbors_grids
   integer,dimension(1:threetondim),save::lll_loc,mmm_loc
 
   ! fetch magic indices
@@ -458,16 +379,10 @@ subroutine get3cubepos(ind_grid,ind,nbors_father_cells,nbors_father_grids,ng)
 
            inbor=1+ii+2*jj+4*kk
            do i=1,ng
-              nbors_grids(i,inbor)=ind_grid3(i)
+              nbors_father_grids(i,inbor)=ind_grid3(i)
            end do
 
         end do
-     end do
-  end do
-
-  do j=1,twotondim
-     do i=1,ng
-        nbors_father_grids(i,j)=nbors_grids(i,j)
      end do
   end do
 
@@ -476,8 +391,9 @@ subroutine get3cubepos(ind_grid,ind,nbors_father_cells,nbors_father_grids,ng)
      icell=mmm_loc(j)
      iskip=ncoarse+(icell-1)*ngridmax
      do i=1,ng
-        if(nbors_grids(i,igrid)>0)then
-           nbors_father_cells(i,j)=iskip+nbors_grids(i,igrid)
+        !nbors_father_cells(i,j) = merge(iskip+nbors_father_grids(i,igrid),0,(nbors_father_grids(i,igrid)>0))
+        if(nbors_father_grids(i,igrid)>0)then
+           nbors_father_cells(i,j)=iskip+nbors_father_grids(i,igrid)
         else
            nbors_father_cells(i,j)=0
         endif

--- a/amr/nbors_utils.f90
+++ b/amr/nbors_utils.f90
@@ -285,8 +285,8 @@ subroutine get3cubepos(ind_grid,ind,nbors_cells,ng)
   do j=1,threetondim
 
      ! Fetch magic indices
-     lll_loc = lll(:,j)
-     mmm_loc = mmm(:,j)
+     lll_loc = lll(j,:)
+     mmm_loc = mmm(j,:)
 
      do i=1,ng
         ! index in the list of nbor_grids of the grid in which the j-th neighbor cell should be located

--- a/amr/nbors_utils.f90
+++ b/amr/nbors_utils.f90
@@ -1,3 +1,119 @@
+subroutine get3cubefather_bis(ind_cell_father,nbors_father_cells,&
+   &                    ncell,ilevel)
+use amr_commons
+implicit none
+integer::ncell,ilevel
+integer,dimension(1:nvector)::ind_cell_father
+integer,dimension(1:nvector,1:threetondim)::nbors_father_cells
+!------------------------------------------------------------------
+! This subroutine determines the 3^ndim neighboring father cells
+! of the input father cell. According to the refinement rule,
+! they should be present anytime.
+!------------------------------------------------------------------
+integer::i,j,nxny,i1,j1,k1,ind,iok
+integer::i1min,i1max,j1min,j1max,k1min,k1max,ind_father
+integer,dimension(1:nvector),save::ix,iy,iz,iix,iiy,iiz
+integer,dimension(1:nvector),save::pos,ind_grid_father,ind_grid_ok
+integer,dimension(1:nvector,1:threetondim),save::nbors_father_ok
+logical::oups
+
+nxny=nx*ny
+
+if(ilevel==1)then  ! Easy...
+
+   do i=1,ncell
+      iz(i)=(ind_cell_father(i)-1)/nxny
+      iy(i)=(ind_cell_father(i)-1-iz(i)*nxny)/nx
+      ix(i)=(ind_cell_father(i)-1-iy(i)*nx-iz(i)*nxny)
+   end do
+
+   i1min=0; i1max=0
+   if(ndim > 0)i1max=2
+   j1min=0; j1max=0
+   if(ndim > 1)j1max=2
+   k1min=0; k1max=0
+   if(ndim > 2)k1max=2
+
+   ! Loop over 3^ndim neighboring father cells
+   do k1=k1min,k1max
+      iiz=iz
+      if(ndim > 2)then
+         do i=1,ncell
+            iiz(i)=iz(i)+k1-1
+            if(iiz(i) < 0   )iiz(i)=nz-1
+            if(iiz(i) > nz-1)iiz(i)=0
+         end do
+      end if
+      do j1=j1min,j1max
+         iiy=iy
+         if(ndim > 1)then
+            do i=1,ncell
+               iiy(i)=iy(i)+j1-1
+               if(iiy(i) < 0   )iiy(i)=ny-1
+               if(iiy(i) > ny-1)iiy(i)=0
+            end do
+         end if
+         do i1=i1min,i1max
+            iix=ix
+            if(ndim > 0)then
+               do i=1,ncell
+                  iix(i)=ix(i)+i1-1
+                  if(iix(i) < 0   )iix(i)=nx-1
+                  if(iix(i) > nx-1)iix(i)=0
+               end do
+            end if
+            ind_father=1+i1+3*j1+9*k1
+            do i=1,ncell
+               nbors_father_cells(i,ind_father)=1 &
+                    & +iix(i) &
+                    & +iiy(i)*nx &
+                    & +iiz(i)*nxny
+            end do
+         end do
+      end do
+   end do
+
+else    ! else, more complicated...
+
+   do i=1,ncell
+      ! Get father cell position in the grid
+      pos(i)=(ind_cell_father(i)-ncoarse-1)/ngridmax+1
+      ! Get father grid
+      ind_grid_father(i)=ind_cell_father(i)-ncoarse-(pos(i)-1)*ngridmax
+   end do
+
+   ! Loop over position
+   do ind=1,twotondim
+
+      ! Select father cells that sit at position ind
+      iok=0
+      do i=1,ncell
+         if(pos(i)==ind)then
+            iok=iok+1
+            ind_grid_ok(iok)=ind_grid_father(i)
+         end if
+      end do
+
+      if(iok>0)then
+         call get3cubepos_bis(ind_grid_ok,ind,nbors_father_ok,iok)
+      endif
+
+      ! Store neighboring father cells for selected cells
+      do j=1,threetondim
+         iok=0
+         do i=1,ncell
+            if(pos(i)==ind)then
+               iok=iok+1
+               nbors_father_cells(i,j)=nbors_father_ok(iok,j)
+            end if
+         end do
+      end do
+
+   end do
+
+end if
+
+end subroutine get3cubefather_bis
 !##############################################################
 !##############################################################
 !##############################################################
@@ -39,11 +155,7 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,&
 
      do i=1,ncell
         iz(i)=(ind_cell_father(i)-1)/nxny
-     end do
-     do i=1,ncell
         iy(i)=(ind_cell_father(i)-1-iz(i)*nxny)/nx
-     end do
-     do i=1,ncell
         ix(i)=(ind_cell_father(i)-1-iy(i)*nx-iz(i)*nxny)
      end do
 
@@ -93,13 +205,6 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,&
         end do
      end do
 
-     i1min=0; i1max=0
-     if(ndim > 0)i1max=1
-     j1min=0; j1max=0
-     if(ndim > 1)j1max=1
-     k1min=0; k1max=0
-     if(ndim > 2)k1max=1
-
      ! Loop over 2^ndim neighboring father grids
      do k1=k1min,k1max
         iiz=iz
@@ -141,12 +246,10 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,&
 
   else    ! else, more complicated...
 
-     ! Get father cell position in the grid
      do i=1,ncell
+        ! Get father cell position in the grid
         pos(i)=(ind_cell_father(i)-ncoarse-1)/ngridmax+1
-     end do
-     ! Get father grid
-     do i=1,ncell
+        ! Get father grid
         ind_grid_father(i)=ind_cell_father(i)-ncoarse-(pos(i)-1)*ngridmax
      end do
 
@@ -162,8 +265,9 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,&
            end if
         end do
 
-        if(iok>0)&
-        & call get3cubepos(ind_grid_ok,ind,nbors_father_ok,nbors_grids_ok,iok)
+        if(iok>0)then
+           call get3cubepos(ind_grid_ok,ind,nbors_father_ok,nbors_grids_ok,iok)
+        endif
 
         ! Store neighboring father cells for selected cells
         do j=1,threetondim
@@ -192,6 +296,106 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,&
   end if
 
 end subroutine get3cubefather
+!##############################################################
+!##############################################################
+!##############################################################
+!##############################################################
+subroutine get3cubepos_bis(ind_grid,ind,nbors_father_cells,ng)
+  use amr_commons
+  implicit none
+  integer::ng,ind
+  integer,dimension(1:nvector)::ind_grid
+  integer,dimension(1:nvector,1:threetondim)::nbors_father_cells
+  !--------------------------------------------------------------------
+  ! This subroutine determines the 3^ndim neighboring father cells
+  ! of the input cell at position ind in grid ind_grid. According to
+  ! the refinements rules and since the input cell is refined,
+  ! they should be present anytime.
+  !--------------------------------------------------------------------
+  integer::i,j,iskip
+  integer::ii,iimin,iimax
+  integer::jj,jjmin,jjmax
+  integer::kk,kkmin,kkmax
+  integer::icell,igrid,inbor
+  integer,dimension(1:8)::iii=(/1,2,1,2,1,2,1,2/)
+  integer,dimension(1:8)::jjj=(/3,3,4,4,3,3,4,4/)
+  integer,dimension(1:8)::kkk=(/5,5,5,5,6,6,6,6/)
+  integer,dimension(1:27,1:8,1:3)::lll,mmm
+  integer,dimension(1:nvector),save::ind_grid1,ind_grid2,ind_grid3
+  integer,dimension(1:nvector,1:twotondim),save::nbors_grids
+
+  call getindices3cube(lll,mmm)
+
+  iimin=0; iimax=0
+  if(ndim>0)iimax=1
+  jjmin=0; jjmax=0
+  if(ndim>1)jjmax=1
+  kkmin=0; kkmax=0
+  if(ndim>2)kkmax=1
+
+  do kk=kkmin,kkmax
+     do i=1,ng
+        ind_grid1(i)=ind_grid(i)
+     end do
+     if(kk>0)then
+        inbor=kkk(ind)
+        do i=1,ng
+           if(ind_grid(i)>0)then
+              ind_grid1(i)=son(nbor(ind_grid(i),inbor))
+           endif
+        end do
+     end if
+
+     do jj=jjmin,jjmax
+        do i=1,ng
+           ind_grid2(i)=ind_grid1(i)
+        end do
+        if(jj>0)then
+           inbor=jjj(ind)
+           do i=1,ng
+              if(ind_grid1(i)>0)then
+                 ind_grid2(i)=son(nbor(ind_grid1(i),inbor))
+              endif
+           end do
+        end if
+
+        do ii=iimin,iimax
+           do i=1,ng
+              ind_grid3(i)=ind_grid2(i)
+           end do
+           if(ii>0)then
+              inbor=iii(ind)
+              do i=1,ng
+                 if(ind_grid2(i)>0)then
+                    ind_grid3(i)=son(nbor(ind_grid2(i),inbor))
+                 endif
+              end do
+           end if
+
+           inbor=1+ii+2*jj+4*kk
+           do i=1,ng
+              nbors_grids(i,inbor)=ind_grid3(i)
+           end do
+
+        end do
+     end do
+  end do
+
+  do j=1,threetondim
+     igrid=lll(j,ind,ndim)
+     icell=mmm(j,ind,ndim)
+     iskip=ncoarse+(icell-1)*ngridmax
+     do i=1,ng
+        nbors_father_cells(i,j) = merge(iskip+nbors_grids(i,igrid),0,(nbors_grids(i,igrid)>0))
+        !if(nbors_grids(i,igrid)>0)then
+        !   nbors_father_cells(i,j)=iskip+nbors_grids(i,igrid)
+        !else
+        !   nbors_father_cells(i,j)=0
+        !endif
+     end do
+  end do
+
+end subroutine get3cubepos_bis
 !##############################################################
 !##############################################################
 !##############################################################

--- a/amr/nbors_utils.f90
+++ b/amr/nbors_utils.f90
@@ -93,34 +93,36 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,ncell,ilevel)
         ind_grid_father(i)=ind_cell_father(i)-iskip
      end do
 
+     call get3cubepos(ind_grid_father,pos,nbors_father_cells,ncell)
+
      ! Loop over position
      ! TC: we could just call 
-     do ind=1,twotondim
+     !do ind=1,twotondim
 
         ! Gather father cells that sit at position ind
         ! TC this is to make call to get3cubepos vectorizable?
         ! could just make ind an nvector array?
-        iok=0
-        do i=1,ncell
-           if(pos(i)==ind)then
-              iok=iok+1
-              ind_grid_ok(iok)=ind_grid_father(i)
-              ind_cell_ok(iok)=i
-           end if
-        end do
+        !iok=0
+        !do i=1,ncell
+        !   if(pos(i)==ind)then
+        !      iok=iok+1
+         !     ind_grid_ok(iok)=ind_grid_father(i)
+         !     ind_cell_ok(iok)=i
+         !  end if
+        !end do
 
-        if(iok>0)then
-           call get3cubepos(ind_grid_ok,ind,nbors_father_ok,iok)
-
+        !if(iok>0)then
+        !   call get3cubepos(ind_grid_ok,ind,nbors_father_ok,iok)
+!
            ! Store neighboring father cells for selected cells
-           do j=1,threetondim
-              do i=1,iok
-                 nbors_father_cells(ind_cell_ok(i),j)=nbors_father_ok(i,j)
-              end do
-           end do
-        end if
+ !          do j=1,threetondim
+  !!            do i=1,iok
+    !             nbors_father_cells(ind_cell_ok(i),j)=nbors_father_ok(i,j)
+     !!         end do
+       !    end do
+        !end if
 
-     end do
+     !end do
 
   end if
 
@@ -217,33 +219,35 @@ subroutine get3cubefather_grids(ind_cell_father,nbors_father_grids,ncell,ilevel)
         ind_grid_father(i)=ind_cell_father(i)-iskip
      end do
 
+     call get_grids_of_nbor_cells(ind_grid_father,pos,nbors_father_grids,ncell)
+
      ! Loop over position
-     do ind=1,twotondim
+     !do ind=1,twotondim
 
         ! Select father cells that sit at position ind
-        iok=0
-        do i=1,ncell
-           if(pos(i)==ind)then
-              iok=iok+1
-              ind_grid_ok(iok)=ind_grid_father(i)
-              ind_cell_ok(iok)=i
-           end if
-        end do
+        !iok=0
+        !do i=1,ncell
+        !   if(pos(i)==ind)then
+        !      iok=iok+1
+        !      ind_grid_ok(iok)=ind_grid_father(i)
+        !      ind_cell_ok(iok)=i
+        !   end if
+        !end do
 
-        if(iok>0)then
+        !if(iok>0)then
            ! Get the grids that contain the 3x3x3 neighbor cells of
            ! the cell at position ind in the grid ind_grid_ok
-           call get_grids_of_nbor_cells(ind_grid_ok,ind,nbors_grids_ok,iok)
+        !   call get_grids_of_nbor_cells(ind_grid_ok,ind,nbors_grids_ok,iok)
 
            ! Store neighboring father grids for selected cells
-           do j=1,twotondim
-              do i=1,iok
-                 nbors_father_grids(ind_cell_ok(i),j)=nbors_grids_ok(i,j)
-              end do
-           end do
-        endif
+         !  do j=1,twotondim
+         !     do i=1,iok
+         !        nbors_father_grids(ind_cell_ok(i),j)=nbors_grids_ok(i,j)
+         !     end do
+         !  end do
+        !endif
 
-     end do
+    ! end do
 
   end if
 
@@ -256,8 +260,8 @@ subroutine get3cubepos(ind_grid,ind,nbors_cells,ng)
   use amr_commons
   use amr_constants, only:lll,mmm
   implicit none
-  integer,intent(in)::ng,ind
-  integer,dimension(1:nvector),intent(in)::ind_grid
+  integer,intent(in)::ng
+  integer,dimension(1:nvector),intent(in)::ind_grid,ind
   integer,dimension(1:nvector,1:threetondim)::nbors_cells
   !--------------------------------------------------------------------
   ! This subroutine determines the 3^ndim neighboring cells
@@ -287,17 +291,20 @@ subroutine get3cubepos(ind_grid,ind,nbors_cells,ng)
   call get_grids_of_nbor_cells(ind_grid,ind,nbors_grids,ng)
 
   ! Fetch magic indices
-  lll_loc = lll(:,ind)
-  mmm_loc = mmm(:,ind)
+  !lll_loc = lll!(:,ind)
+  !mmm_loc = mmm!(:,ind)
 
   ! Loop over 3x3x3 neighbor cells
   do j=1,threetondim
      ! index in the list of nbor_grids of the grid in which the j-th neighbor cell should be located
-     igrid=lll_loc(j)
+     !igrid=lll_loc(j)
      ! position in which the neighbor cell should be located in its grid
-     icell=mmm_loc(j)
-     iskip=ncoarse+(icell-1)*ngridmax
+     !icell=mmm_loc(j)
+     !iskip=ncoarse+(icell-1)*ngridmax
      do i=1,ng
+        igrid = lll(j,ind(i))
+        icell = mmm(j,ind(i))
+        iskip=ncoarse+(icell-1)*ngridmax
         ! If the grid for neighbor cell j exists,
         ! determine its index based on the index of the grid in which is sits
         ! otherwise set 0.
@@ -315,8 +322,8 @@ end subroutine get3cubepos
 subroutine get_grids_of_nbor_cells(ind_grid,ind,nbors_grids,ng)
   use amr_commons
   implicit none
-  integer,intent(in)::ng,ind
-  integer,dimension(1:nvector),intent(in)::ind_grid
+  integer,intent(in)::ng
+  integer,dimension(1:nvector),intent(in)::ind_grid,ind
   integer,dimension(1:nvector,1:twotondim),intent(out)::nbors_grids
   !--------------------------------------------------------------------
   ! This subroutine determines the two^ndim grids that contain the
@@ -368,10 +375,10 @@ subroutine get_grids_of_nbor_cells(ind_grid,ind,nbors_grids,ng)
         ind_grid1(i)=ind_grid(i)
      end do
      if(kk>0)then
-        inbor=kkk(ind)
+        !inbor=kkk(ind)
         do i=1,ng
            if(ind_grid(i)>0)then
-              ind_grid1(i)=son(nbor(ind_grid(i),inbor))
+              ind_grid1(i)=son(nbor(ind_grid(i),kkk(ind(i))))!inbor))
            endif
         end do
      end if
@@ -381,10 +388,10 @@ subroutine get_grids_of_nbor_cells(ind_grid,ind,nbors_grids,ng)
            ind_grid2(i)=ind_grid1(i)
         end do
         if(jj>0)then
-           inbor=jjj(ind)
+           !inbor=jjj(ind)
            do i=1,ng
               if(ind_grid1(i)>0)then
-                 ind_grid2(i)=son(nbor(ind_grid1(i),inbor))
+                 ind_grid2(i)=son(nbor(ind_grid1(i),jjj(ind(i))))!inbor))
               endif
            end do
         end if
@@ -394,10 +401,10 @@ subroutine get_grids_of_nbor_cells(ind_grid,ind,nbors_grids,ng)
               ind_grid3(i)=ind_grid2(i)
            end do
            if(ii>0)then
-              inbor=iii(ind)
+              !inbor=iii(ind)
               do i=1,ng
                  if(ind_grid2(i)>0)then
-                    ind_grid3(i)=son(nbor(ind_grid2(i),inbor))
+                    ind_grid3(i)=son(nbor(ind_grid2(i),iii(ind(i))))!inbor))
                  endif
               end do
            end if

--- a/hydro/godunov_fine.f90
+++ b/hydro/godunov_fine.f90
@@ -483,7 +483,6 @@ subroutine godfine1(ind_grid,ncache,ilevel)
   ! coarser level if necessary.
   !-------------------------------------------------------------------
   integer ,dimension(1:nvector,1:threetondim     ),save::nbors_father_cells
-  integer ,dimension(1:nvector,1:twotondim       ),save::nbors_father_grids
   integer ,dimension(1:nvector,0:twondim         ),save::ibuffer_father
   real(dp),dimension(1:nvector,0:twondim  ,1:nvar),save::u1
   real(dp),dimension(1:nvector,1:twotondim,1:nvar),save::u2
@@ -535,7 +534,7 @@ subroutine godfine1(ind_grid,ncache,ilevel)
   do i=1,ncache
      ind_cell(i)=father(ind_grid(i))
   end do
-  call get3cubefather(ind_cell,nbors_father_cells,nbors_father_grids,ncache,ilevel)
+  call get3cubefather(ind_cell,nbors_father_cells,ncache,ilevel)
 
   !---------------------------
   ! Gather 6x6x6 cells stencil

--- a/mhd/godunov_fine.f90
+++ b/mhd/godunov_fine.f90
@@ -534,7 +534,6 @@ subroutine godfine1(ind_grid,ncache,ilevel)
   ! coarser level if necessary.
   !-------------------------------------------------------------------
   integer ,dimension(1:nvector,1:threetondim     ),save::nbors_father_cells
-  integer ,dimension(1:nvector,1:twotondim       ),save::nbors_father_grids
   integer ,dimension(1:nvector,0:twondim         ),save::ibuffer_father
   integer ,dimension(1:nvector,0:twondim         ),save::ind1
   real(dp),dimension(1:nvector,0:twondim  ,1:nvar+3),save::u1
@@ -587,7 +586,7 @@ subroutine godfine1(ind_grid,ncache,ilevel)
   do i=1,ncache
      ind_cell(i)=father(ind_grid(i))
   end do
-  call get3cubefather(ind_cell,nbors_father_cells,nbors_father_grids,ncache,ilevel)
+  call get3cubefather(ind_cell,nbors_father_cells,ncache,ilevel)
 
   !---------------------------
   ! Gather 6x6x6 cells stencil

--- a/mhd/uplmde.f90
+++ b/mhd/uplmde.f90
@@ -109,7 +109,6 @@ subroutine diffine1(ind_grid,ncache,dtdiff,ilevel)
   ! conservative variables are stored in array unew(:).
   !-------------------------------------------------------------------
   integer ,dimension(1:nvector,1:threetondim     ),save::nbors_father_cells
-  integer ,dimension(1:nvector,1:twotondim       ),save::nbors_father_grids
   integer ,dimension(1:nvector,0:twondim         ),save::ibuffer_father
   real(dp),dimension(1:nvector,0:twondim  ,1:6   ),save::B1
   integer ,dimension(1:nvector,0:twondim)         ,save::ind1
@@ -151,7 +150,7 @@ subroutine diffine1(ind_grid,ncache,dtdiff,ilevel)
   do i=1,ncache
      ind_cell(i)=father(ind_grid(i))
   end do
-  call get3cubefather(ind_cell,nbors_father_cells,nbors_father_grids,ncache,ilevel)
+  call get3cubefather(ind_cell,nbors_father_cells,ncache,ilevel)
 
   !---------------------------
   ! Gather 6x6x6 cells stencil

--- a/pm/clump_finder.f90
+++ b/pm/clump_finder.f90
@@ -588,7 +588,6 @@ subroutine neighborsearch(xx,ind_cell,ind_max,np,count,ilevel,action)
   logical ,dimension(1:nvector)::okpeak
   integer ,dimension(1:nvector,1:threetondim),save::nbors_father_cells
   integer ,dimension(1:threetondim)::nbors_father_cells_pass
-  integer ,dimension(1:nvector,1:twotondim),save::nbors_father_grids
   integer::ntestpos,ntp,idim,ipos
 
 #if NDIM==3
@@ -699,7 +698,7 @@ subroutine neighborsearch(xx,ind_cell,ind_max,np,count,ilevel,action)
   do j=1,np
      ind_cell_coarse(j)=father(ind_grid(j))
   end do
-  call get3cubefather(ind_cell_coarse,nbors_father_cells,nbors_father_grids,np,ilevel)
+  call get3cubefather(ind_cell_coarse,nbors_father_cells,np,ilevel)
 
 
   ! initialze logical array
@@ -1372,7 +1371,6 @@ subroutine cic_only(ind_cell,ind_part,ind_grid_part,x0,ng,np,ilevel)
   real(dp)::dx,dx_loc,scale,vol_loc
   ! Grid-based arrays
   integer ,dimension(1:nvector,1:threetondim),save::nbors_father_cells
-  integer ,dimension(1:nvector,1:twotondim),save::nbors_father_grids
   ! Particle-based arrays
   logical ,dimension(1:nvector),save::ok
   real(dp),dimension(1:nvector),save::mmm
@@ -1395,7 +1393,7 @@ subroutine cic_only(ind_cell,ind_part,ind_grid_part,x0,ng,np,ilevel)
   vol_loc=dx_loc**ndim
 
   ! Gather neighboring father cells (should be present anytime !)
-  call get3cubefather(ind_cell,nbors_father_cells,nbors_father_grids,ng,ilevel)
+  call get3cubefather(ind_cell,nbors_father_cells,ng,ilevel)
 
   ! Rescale particle position at level ilevel
   do idim=1,ndim
@@ -1606,7 +1604,6 @@ subroutine tsc_only(ind_cell,ind_part,ind_grid_part,x0,ng,np,ilevel)
   real(dp)::dx,dx_loc,scale,vol_loc
   ! Grid-based arrays
   integer ,dimension(1:nvector,1:threetondim),save::nbors_father_cells
-  integer ,dimension(1:nvector,1:twotondim),save::nbors_father_grids
   ! Particle-based arrays
   logical ,dimension(1:nvector),save::ok,abandoned
   real(dp),dimension(1:nvector),save::mmm
@@ -1636,7 +1633,7 @@ subroutine tsc_only(ind_cell,ind_part,ind_grid_part,x0,ng,np,ilevel)
   vol_loc=dx_loc**ndim
 
   ! Gather neighboring father cells (should be present at anytime!)
-  call get3cubefather(ind_cell,nbors_father_cells,nbors_father_grids,ng,ilevel)
+  call get3cubefather(ind_cell,nbors_father_cells,ng,ilevel)
 
   ! Rescale particle position at level ilevel
   do idim=1,ndim

--- a/pm/feedback.f90
+++ b/pm/feedback.f90
@@ -176,7 +176,6 @@ subroutine feedbk(ind_grid,ind_part,ind_grid_part,ng,np,ilevel)
   real(dp),dimension(1:nvector,1:ndim),save::x0
   integer ,dimension(1:nvector),save::ind_cell
   integer ,dimension(1:nvector,1:threetondim),save::nbors_father_cells
-  integer ,dimension(1:nvector,1:twotondim),save::nbors_father_grids
   ! Particle based arrays
   logical,dimension(1:nvector),save::ok
   real(dp),dimension(1:nvector),save::mloss,mzloss,ethermal,ekinetic,dteff
@@ -244,7 +243,7 @@ subroutine feedbk(ind_grid,ind_part,ind_grid_part,ng,np,ilevel)
   do i=1,ng
      ind_cell(i)=father(ind_grid(i))
   end do
-  call get3cubefather(ind_cell,nbors_father_cells,nbors_father_grids,ng,ilevel)
+  call get3cubefather(ind_cell,nbors_father_cells,ng,ilevel)
 
   ! Rescale position at level ilevel
   do idim=1,ndim

--- a/pm/move_fine.f90
+++ b/pm/move_fine.f90
@@ -211,7 +211,6 @@ subroutine move1(ind_grid,ind_part,ind_grid_part,ng,np,ilevel)
   integer ,dimension(1:nvector),save::father_cell
   real(dp),dimension(1:nvector,1:ndim),save::x0
   integer ,dimension(1:nvector,1:threetondim),save::nbors_father_cells
-  integer ,dimension(1:nvector,1:twotondim),save::nbors_father_grids
   ! Particle-based arrays
   logical ,dimension(1:nvector),save::ok
   real(dp),dimension(1:nvector,1:ndim),save::x,ff,new_xp,new_vp,dd,dg
@@ -244,7 +243,7 @@ subroutine move1(ind_grid,ind_part,ind_grid_part,ng,np,ilevel)
   do i=1,ng
      father_cell(i)=father(ind_grid(i))
   end do
-  call get3cubefather(father_cell,nbors_father_cells,nbors_father_grids,&
+  call get3cubefather_bis(father_cell,nbors_father_cells,&
        & ng,ilevel)
 
   ! Rescale particle position at level ilevel

--- a/pm/move_fine.f90
+++ b/pm/move_fine.f90
@@ -243,7 +243,7 @@ subroutine move1(ind_grid,ind_part,ind_grid_part,ng,np,ilevel)
   do i=1,ng
      father_cell(i)=father(ind_grid(i))
   end do
-  call get3cubefather_bis(father_cell,nbors_father_cells,&
+  call get3cubefather(father_cell,nbors_father_cells,&
        & ng,ilevel)
 
   ! Rescale particle position at level ilevel

--- a/pm/particle_tree.f90
+++ b/pm/particle_tree.f90
@@ -310,7 +310,7 @@ subroutine check_tree(ind_grid,ind_part,ind_grid_part,ng,np,ilevel)
   do i=1,ng
      ind_father(i)=father(ind_grid(i))
   end do
-  call get3cubefather_bis(ind_father,nbors_father_cells,ng,ilevel)
+  call get3cubefather(ind_father,nbors_father_cells,ng,ilevel)
 
   ! Compute particle position in 3-cube
   error=.false.

--- a/pm/particle_tree.f90
+++ b/pm/particle_tree.f90
@@ -281,7 +281,6 @@ subroutine check_tree(ind_grid,ind_part,ind_grid_part,ng,np,ilevel)
   real(dp),dimension(1:3)::xbound
   ! Grid-based arrays
   integer ,dimension(1:nvector,1:threetondim),save::nbors_father_cells
-  integer ,dimension(1:nvector,1:twotondim),save::nbors_father_grids
   real(dp),dimension(1:nvector,1:ndim),save::x0
   integer ,dimension(1:nvector),save::ind_father
   ! Particle-based arrays
@@ -311,7 +310,7 @@ subroutine check_tree(ind_grid,ind_part,ind_grid_part,ng,np,ilevel)
   do i=1,ng
      ind_father(i)=father(ind_grid(i))
   end do
-  call get3cubefather(ind_father,nbors_father_cells,nbors_father_grids,ng,ilevel)
+  call get3cubefather_bis(ind_father,nbors_father_cells,ng,ilevel)
 
   ! Compute particle position in 3-cube
   error=.false.

--- a/pm/rho_fine.f90
+++ b/pm/rho_fine.f90
@@ -366,7 +366,7 @@ subroutine cic_amr(ind_cell,ind_part,ind_grid_part,x0,ng,np,ilevel)
 
 
   ! Gather neighboring father cells (should be present anytime !)
-  call get3cubefather_bis(ind_cell,nbors_father_cells,ng,ilevel)
+  call get3cubefather(ind_cell,nbors_father_cells,ng,ilevel)
 
   ! Rescale particle position at level ilevel
   do idim=1,ndim
@@ -909,7 +909,7 @@ subroutine cic_cell(ind_grid,ngrid,ilevel)
   end do
 
   ! Gather 3x3x3 neighboring parent cells
-  call get3cubefather_bis(ind_cell,nbors_father_cells,ngrid,ilevel)
+  call get3cubefather(ind_cell,nbors_father_cells,ngrid,ilevel)
 
   ! Loop over grid cells
   do ind_son=1,twotondim
@@ -1151,7 +1151,7 @@ subroutine tsc_amr(ind_cell,ind_part,ind_grid_part,x0,ng,np,ilevel)
   vol_loc=dx_loc**ndim
 
   ! Gather neighboring father cells (should be present at anytime!)
-  call get3cubefather_bis(ind_cell,nbors_father_cells,ng,ilevel)
+  call get3cubefather(ind_cell,nbors_father_cells,ng,ilevel)
 
   ! Rescale particle position at level ilevel
   do idim=1,ndim
@@ -1472,7 +1472,7 @@ subroutine tsc_cell(ind_grid,ngrid,ilevel)
   end do
 
   ! Gather 3x3x3 neighboring parent cells
-  call get3cubefather_bis(ind_cell,nbors_father_cells,ngrid,ilevel)
+  call get3cubefather(ind_cell,nbors_father_cells,ngrid,ilevel)
 
   ! Loop over grid cells
   do ind_son=1,twotondim

--- a/pm/rho_fine.f90
+++ b/pm/rho_fine.f90
@@ -341,7 +341,6 @@ subroutine cic_amr(ind_cell,ind_part,ind_grid_part,x0,ng,np,ilevel)
   real(dp)::dx,dx_loc,scale,vol_loc
   ! Grid-based arrays
   integer ,dimension(1:nvector,1:threetondim),save::nbors_father_cells
-  integer ,dimension(1:nvector,1:twotondim),save::nbors_father_grids
   ! Particle-based arrays
   logical ,dimension(1:nvector),save::ok
   real(dp),dimension(1:nvector),save::mmm
@@ -367,7 +366,7 @@ subroutine cic_amr(ind_cell,ind_part,ind_grid_part,x0,ng,np,ilevel)
 
 
   ! Gather neighboring father cells (should be present anytime !)
-  call get3cubefather(ind_cell,nbors_father_cells,nbors_father_grids,ng,ilevel)
+  call get3cubefather_bis(ind_cell,nbors_father_cells,ng,ilevel)
 
   ! Rescale particle position at level ilevel
   do idim=1,ndim
@@ -880,7 +879,6 @@ subroutine cic_cell(ind_grid,ngrid,ilevel)
   integer::i,j,idim,ind_cell_son,iskip_son,np,ind_son,nx_loc,ind
   integer ,dimension(1:nvector),save::ind_cell
   integer ,dimension(1:nvector,1:threetondim),save::nbors_father_cells
-  integer ,dimension(1:nvector,1:twotondim),save::nbors_father_grids
   ! Particle-based arrays
   logical ,dimension(1:nvector),save::ok
   real(dp),dimension(1:nvector),save::mmm
@@ -911,7 +909,7 @@ subroutine cic_cell(ind_grid,ngrid,ilevel)
   end do
 
   ! Gather 3x3x3 neighboring parent cells
-  call get3cubefather(ind_cell,nbors_father_cells,nbors_father_grids,ngrid,ilevel)
+  call get3cubefather_bis(ind_cell,nbors_father_cells,ngrid,ilevel)
 
   ! Loop over grid cells
   do ind_son=1,twotondim
@@ -1130,7 +1128,6 @@ subroutine tsc_amr(ind_cell,ind_part,ind_grid_part,x0,ng,np,ilevel)
   real(dp)::dx,dx_loc,scale,vol_loc
   ! Grid-based arrays
   integer ,dimension(1:nvector,1:threetondim),save::nbors_father_cells
-  integer ,dimension(1:nvector,1:twotondim),save::nbors_father_grids
   ! Particle-based arrays
   logical ,dimension(1:nvector),save::ok,abandoned
   real(dp),dimension(1:nvector),save::mmm
@@ -1154,7 +1151,7 @@ subroutine tsc_amr(ind_cell,ind_part,ind_grid_part,x0,ng,np,ilevel)
   vol_loc=dx_loc**ndim
 
   ! Gather neighboring father cells (should be present at anytime!)
-  call get3cubefather(ind_cell,nbors_father_cells,nbors_father_grids,ng,ilevel)
+  call get3cubefather_bis(ind_cell,nbors_father_cells,ng,ilevel)
 
   ! Rescale particle position at level ilevel
   do idim=1,ndim
@@ -1445,7 +1442,6 @@ subroutine tsc_cell(ind_grid,ngrid,ilevel)
   integer::i,j,idim,ind_cell_son,iskip_son,np,ind_son,nx_loc,ind
   integer ,dimension(1:nvector),save::ind_cell
   integer ,dimension(1:nvector,1:threetondim),save::nbors_father_cells
-  integer ,dimension(1:nvector,1:twotondim),save::nbors_father_grids
   ! Particle-based arrays
   logical ,dimension(1:nvector),save::ok
   real(dp),dimension(1:nvector),save::mmm
@@ -1476,7 +1472,7 @@ subroutine tsc_cell(ind_grid,ngrid,ilevel)
   end do
 
   ! Gather 3x3x3 neighboring parent cells
-  call get3cubefather(ind_cell,nbors_father_cells,nbors_father_grids,ngrid,ilevel)
+  call get3cubefather_bis(ind_cell,nbors_father_cells,ngrid,ilevel)
 
   ! Loop over grid cells
   do ind_son=1,twotondim

--- a/pm/sink_particle.f90
+++ b/pm/sink_particle.f90
@@ -2629,7 +2629,6 @@ subroutine cic_get_cells(indp,xx,vol,ok,ind_grid,xpart,ind_grid_part,ng,np,ileve
   ! Grid-based arrays
   integer ,dimension(1:nvector)::ind_cell
   integer ,dimension(1:nvector,1:threetondim),save::nbors_father_cells
-  integer ,dimension(1:nvector,1:twotondim),save::nbors_father_grids
   ! Particle-based arrays
   real(dp),dimension(1:nvector,1:ndim),save::x,dd,dg
   integer ,dimension(1:nvector,1:ndim),save::ig,id,igg,igd,icg,icd
@@ -2670,7 +2669,7 @@ subroutine cic_get_cells(indp,xx,vol,ok,ind_grid,xpart,ind_grid_part,ng,np,ileve
   end do
 
   ! Gather neighboring father cells (should be present anytime!)
-  call get3cubefather(ind_cell,nbors_father_cells,nbors_father_grids,ng,ilevel)
+  call get3cubefather(ind_cell,nbors_father_cells,ng,ilevel)
 
   ! Rescale particle position at level ilevel
   do idim=1,ndim

--- a/pm/sink_rt_feedback.f90
+++ b/pm/sink_rt_feedback.f90
@@ -210,7 +210,6 @@ SUBROUTINE sink_RT_vsweep_stellar(ind_grid,ind_part,ind_grid_part,ng,np,dt,ileve
   real(dp),dimension(1:nvector,1:ndim),save::x0
   integer ,dimension(1:nvector),save::ind_cell
   integer ,dimension(1:nvector,1:threetondim),save::nbors_father_cells
-  integer ,dimension(1:nvector,1:twotondim),save::nbors_father_grids
   ! Particle based arrays
   logical,dimension(1:nvector),save::ok
   real(dp),dimension(1:nvector,1:ndim),save::x
@@ -250,8 +249,7 @@ SUBROUTINE sink_RT_vsweep_stellar(ind_grid,ind_part,ind_grid_part,ng,np,dt,ileve
   do i=1,ng
      ind_cell(i) = father(ind_grid(i))
   end do
-  call get3cubefather(&
-          ind_cell, nbors_father_cells, nbors_father_grids, ng, ilevel)
+  call get3cubefather(ind_cell, nbors_father_cells, ng, ilevel)
 
   ! Rescale position of stars to positions within 3x3x3 cell supercube
   do idim = 1, ndim

--- a/pm/synchro_fine.f90
+++ b/pm/synchro_fine.f90
@@ -267,7 +267,7 @@ subroutine sync(ind_grid,ind_part,ind_grid_part,ng,np,ilevel)
   do i=1,ng
      ind_cell(i)=father(ind_grid(i))
   end do
-  call get3cubefather_bis(ind_cell,nbors_father_cells,ng,ilevel)
+  call get3cubefather(ind_cell,nbors_father_cells,ng,ilevel)
 
   ! Rescale position at level ilevel
   do idim=1,ndim

--- a/pm/synchro_fine.f90
+++ b/pm/synchro_fine.f90
@@ -238,7 +238,6 @@ subroutine sync(ind_grid,ind_part,ind_grid_part,ng,np,ilevel)
   real(dp),dimension(1:nvector,1:ndim),save::x0
   integer ,dimension(1:nvector),save::ind_cell
   integer ,dimension(1:nvector,1:threetondim),save::nbors_father_cells
-  integer ,dimension(1:nvector,1:twotondim),save::nbors_father_grids
   ! Particle-based arrays
   logical ,dimension(1:nvector),save::ok
   real(dp),dimension(1:nvector),save::dteff
@@ -268,7 +267,7 @@ subroutine sync(ind_grid,ind_part,ind_grid_part,ng,np,ilevel)
   do i=1,ng
      ind_cell(i)=father(ind_grid(i))
   end do
-  call get3cubefather(ind_cell,nbors_father_cells,nbors_father_grids,ng,ilevel)
+  call get3cubefather_bis(ind_cell,nbors_father_cells,ng,ilevel)
 
   ! Rescale position at level ilevel
   do idim=1,ndim

--- a/pm/unbinding.f90
+++ b/pm/unbinding.f90
@@ -1274,7 +1274,6 @@ subroutine unbinding_neighborsearch(ind_cell,np,jlevel)
   real(dp),dimension(1:3)::skip_loc
   integer ,dimension(1:nvector,1:threetondim),save::nbors_father_cells
   integer ,dimension(1:threetondim)::nbors_father_cells_pass
-  integer ,dimension(1:nvector,1:twotondim),save::nbors_father_grids
   integer::ntestpos,ntp,idim,ipos
 
   real(dp),dimension(1:3)::this_cellpos
@@ -1379,7 +1378,7 @@ subroutine unbinding_neighborsearch(ind_cell,np,jlevel)
   do j=1,np
     ind_cell_coarse(j)=father(ind_grid(j))
   enddo
-  call get3cubefather(ind_cell_coarse,nbors_father_cells,nbors_father_grids,np,jlevel)
+  call get3cubefather(ind_cell_coarse,nbors_father_cells,np,jlevel)
 
 
   do j=1,np

--- a/poisson/interpol_phi.f90
+++ b/poisson/interpol_phi.f90
@@ -53,7 +53,7 @@ subroutine interpol_phi(ind_cell,phi_int,ncell,ilevel,icount)
 
   ! Mesh size at level ilevel
   dx=0.5D0**ilevel
-  call get3cubefather_bis(ind_cell,nbors_father_cells,ncell,ilevel)
+  call get3cubefather(ind_cell,nbors_father_cells,ncell,ilevel)
 
   ! Third order phi interpolation
   do ind=1,twotondim

--- a/poisson/interpol_phi.f90
+++ b/poisson/interpol_phi.f90
@@ -15,7 +15,6 @@ subroutine interpol_phi(ind_cell,phi_int,ncell,ilevel,icount)
   ! onto the first fine step)
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  integer ,dimension(1:nvector,1:twotondim),save::nbors_father_grids
   integer ,dimension(1:nvector,1:threetondim),save::nbors_father_cells
   integer::i,ind,indice,ind_average,ind_father
   real(dp)::dx,tfrac
@@ -54,7 +53,7 @@ subroutine interpol_phi(ind_cell,phi_int,ncell,ilevel,icount)
 
   ! Mesh size at level ilevel
   dx=0.5D0**ilevel
-  call get3cubefather(ind_cell,nbors_father_cells,nbors_father_grids,ncell,ilevel)
+  call get3cubefather_bis(ind_cell,nbors_father_cells,ncell,ilevel)
 
   ! Third order phi interpolation
   do ind=1,twotondim

--- a/poisson/multigrid_fine_coarse.f90
+++ b/poisson/multigrid_fine_coarse.f90
@@ -517,7 +517,6 @@ subroutine interpolate_and_correct_coarse(ifinelevel)
 
    integer,  dimension(1:nvector), save                :: igrid_f_amr, icell_amr, cpu_amr
    integer,  dimension(1:nvector,1:threetondim), save  :: nbors_father_cells
-   integer,  dimension(1:nvector,1:twotondim), save    :: nbors_father_grids
    real(dp), dimension(1:nvector), save                :: corr
 
    ! Local constants
@@ -559,7 +558,7 @@ subroutine interpolate_and_correct_coarse(ifinelevel)
       end do
 
       ! Gather 3x3x3 neighboring parent cells
-      call get3cubefather(icell_amr,nbors_father_cells,nbors_father_grids,nbatch,ifinelevel)
+      call get3cubefather_bis(icell_amr,nbors_father_cells,nbatch,ifinelevel)
 
       ! Update solution for fine grid cells
       do ind_f=1,twotondim

--- a/poisson/multigrid_fine_coarse.f90
+++ b/poisson/multigrid_fine_coarse.f90
@@ -558,7 +558,7 @@ subroutine interpolate_and_correct_coarse(ifinelevel)
       end do
 
       ! Gather 3x3x3 neighboring parent cells
-      call get3cubefather_bis(icell_amr,nbors_father_cells,nbatch,ifinelevel)
+      call get3cubefather(icell_amr,nbors_father_cells,nbatch,ifinelevel)
 
       ! Update solution for fine grid cells
       do ind_f=1,twotondim

--- a/poisson/multigrid_fine_commons.f90
+++ b/poisson/multigrid_fine_commons.f90
@@ -456,8 +456,8 @@ subroutine build_parent_comms_mg(active_loc, ifinelevel)
          ind_cell_father(i)=father( active_loc%igrid(istart+i-1) )
       end do
 
-      ! Compute neighbouring father cells and grids
-      call get3cubefather(ind_cell_father,nbors_father_cells, &
+      ! Compute neighbouring father grids
+      call get3cubefather_grids(ind_cell_father, &
          & nbors_father_grids,nbatch,ifinelevel)
 
       ! Now process the twotondim father grids
@@ -612,7 +612,7 @@ subroutine build_parent_comms_mg(active_loc, ifinelevel)
       end do
 
       ! Compute neighbouring father cells
-      call get3cubefather_bis(ind_cell_father,nbors_father_cells,nbatch,icoarselevel)
+      call get3cubefather(ind_cell_father,nbors_father_cells,nbatch,icoarselevel)
 
       ! Now process the father grids
       do ind=1,threetondim

--- a/poisson/multigrid_fine_commons.f90
+++ b/poisson/multigrid_fine_commons.f90
@@ -612,7 +612,7 @@ subroutine build_parent_comms_mg(active_loc, ifinelevel)
       end do
 
       ! Compute neighbouring father cells
-      call get3cubefather(ind_cell_father,nbors_father_cells,nbors_father_grids,nbatch,icoarselevel)
+      call get3cubefather_bis(ind_cell_father,nbors_father_cells,nbatch,icoarselevel)
 
       ! Now process the father grids
       do ind=1,threetondim

--- a/poisson/multigrid_fine_fine.f90
+++ b/poisson/multigrid_fine_fine.f90
@@ -456,7 +456,7 @@ subroutine interpolate_and_correct_fine(ifinelevel)
       end do
 
       ! Gather 3x3x3 neighboring parent cells
-      call get3cubefather_bis(icell_amr,nbors_father_cells, &
+      call get3cubefather(icell_amr,nbors_father_cells, &
               nbatch,ifinelevel)
 
       ! Update solution for fine grid cells

--- a/poisson/multigrid_fine_fine.f90
+++ b/poisson/multigrid_fine_fine.f90
@@ -420,7 +420,6 @@ subroutine interpolate_and_correct_fine(ifinelevel)
 
    integer,  dimension(1:nvector), save               :: igrid_f_amr, icell_amr
    integer,  dimension(1:nvector,1:threetondim), save :: nbors_father_cells
-   integer,  dimension(1:nvector,1:twotondim), save   :: nbors_father_grids
    real(dp), dimension(1:nvector), save               :: corr
 
    ! Local constants
@@ -457,7 +456,7 @@ subroutine interpolate_and_correct_fine(ifinelevel)
       end do
 
       ! Gather 3x3x3 neighboring parent cells
-      call get3cubefather(icell_amr,nbors_father_cells,nbors_father_grids, &
+      call get3cubefather_bis(icell_amr,nbors_father_cells, &
               nbatch,ifinelevel)
 
       ! Update solution for fine grid cells

--- a/rt/rt_godunov_fine.f90
+++ b/rt/rt_godunov_fine.f90
@@ -158,7 +158,6 @@ SUBROUTINE rt_godfine1(ind_grid, ncache, ilevel, dt)
   real(dp)::dt
   integer ,dimension(1:nvector)::ind_grid
   integer ,dimension(1:nvector,1:threetondim),save::nbors_father_cells
-  integer ,dimension(1:nvector,1:twotondim  ),save::nbors_father_grids
   integer ,dimension(1:nvector,0:twondim    ),save::ibuffer_father
   real(dp),dimension(1:nvector,0:twondim  ,1:nrtvar),save::u1
   real(dp),dimension(1:nvector,1:twotondim,1:nrtvar),save::u2
@@ -219,15 +218,11 @@ SUBROUTINE rt_godfine1(ind_grid, ncache, ilevel, dt)
      ind_cell(i)=father(ind_grid(i))
   end do
   ! ..and father cells of neighbor grids:
-  call get3cubefather(ind_cell,nbors_father_cells,nbors_father_grids,ncache,ilevel)
+  call get3cubefather(ind_cell,nbors_father_cells,ncache,ilevel)
   ! now for the parent cell (ind_cell(i)) of each grid i in cache:
   !
   ! nbors_father_cells contains indexes of all it's neighbor cells
   ! (ilevel-1), plus itself, total 3^ndim.
-  !
-  ! nbors_father_grids contains indexes of all the neighboring
-  ! (and containing) grids of the father cell, total 2^ndim
-  ! (in case interpolation is needed I guess)
 
   !---------------------------
   ! Gather 6x6x6 cells stencil

--- a/rt/rt_spectra.f90
+++ b/rt/rt_spectra.f90
@@ -1052,7 +1052,6 @@ SUBROUTINE star_RT_vsweep(ind_grid,ind_part,ind_grid_part,ng,np,dt,ilevel)
   real(dp),dimension(1:nvector,1:ndim),save::x0
   integer ,dimension(1:nvector),save::ind_cell
   integer ,dimension(1:nvector,1:threetondim),save::nbors_father_cells
-  integer ,dimension(1:nvector,1:twotondim),save::nbors_father_grids
   ! Particle based arrays
   logical,dimension(1:nvector),save::ok
   real(dp),dimension(1:nvector,ngroups),save::part_NpInp
@@ -1098,10 +1097,8 @@ SUBROUTINE star_RT_vsweep(ind_grid,ind_part,ind_grid_part,ng,np,dt,ilevel)
      ind_cell(i) = father(ind_grid(i))
   end do
   call get3cubefather(&
-          ind_cell, nbors_father_cells, nbors_father_grids, ng, ilevel)
-  ! now nbors_father cells are a cube of 27 cells with ind_cell in the
-  ! middle and nbors_father_grids are the 8 grids that contain these 27
-  ! cells (though only one of those is fully included in the cube)
+          ind_cell, nbors_father_cells, ng, ilevel)
+  ! now nbors_father_cells are a cube of 27 cells with ind_cell in the middle
 
   ! Rescale position of stars to positions within 3x3x3 cell supercube
   do idim = 1, ndim


### PR DESCRIPTION
**Refactor routines for obtaining the 3cube neighbors**
* The routine get3cubefather is split into its two parts. Before, get3cubefather returned both the _cells_ and the _grids_, but only one of them was actually used after the call. Now, get3cubefather only returns the neighbor _cells_. A new subroutine get3cubefather_grids, returns the grids (only needed for poisson multigrid). This avoid unnecessary computations and memory access. 
* Move the first part of the routine get3cubepos to its own routine, named get_grids_of_nbor_cells, so it can be used by get3cubefather_grids.
* The input ind for get3cubepos and get_grids_of_nbor_cells is now an array of length nvector instead of an integer. This allows to remove the if condition inside the loop over cells to select the cells that sit at position ind, which hinders vectorization and creates more loop iterations:
```
        iok=0
        do i=1,ncell
           if(pos(i)==ind)then
```
* Use merge instead of if-else in get3cubepos, in an attempt to improve vectorization.

These changes reduce the cost of get3cubefather itself to almost nothing. The computational cost is now purely in the subroutines called by get3cubefather, rather than the loops at the end of the routine which were inefficient.
I've measured **performance gains** for several benchmarks:
* cosmo on uniform grid: marenostrum intel 6.2%, meluxina gnu 10.5%
* cosmo with amr:  marenostrum 8.2%, meluxina 11.2%
* sedov on uniform grid: 1-2%

**Documentation**
* Add an overview of the routines at the top of the file.
* Add more detailed descriptions of what each routine is doing.
* Try to make variable naming more intuitive/consistent.

This development was done in the context of the SPACE CoE.