### PR TITLE
simplify save_phi_old to remove allocate inside loop

### DIFF
--- a/amr/amr_step.f90
+++ b/amr/amr_step.f90
@@ -211,7 +211,8 @@ recursive subroutine amr_step(ilevel,icount)
   !--------------------
   if(poisson)then
                                call timer('poisson','start')
-     !save old potential for time-extrapolation at level boundaries
+     ! Save old potential for time-extrapolation at level boundaries
+     ! Needs to be done before rho_fine, because there phi is used as work array
      call save_phi_old(ilevel)
                                call timer('rho','start')
      call rho_fine(ilevel,icount)

--- a/poisson/interpol_phi.f90
+++ b/poisson/interpol_phi.f90
@@ -111,7 +111,7 @@ subroutine save_phi_old(ilevel)
            phi_old(igrid+iskip)=phi(igrid+iskip)
         end do
         igrid=next(igrid)
-      end do 
+      end do
   end do
 
 end subroutine save_phi_old

--- a/poisson/interpol_phi.f90
+++ b/poisson/interpol_phi.f90
@@ -88,12 +88,12 @@ subroutine save_phi_old(ilevel)
   use poisson_commons, only:phi,phi_old
   implicit none
   integer ilevel
-
-  !save the old potential for time extrapolation in case of subcycling
-
+  !--------------------------------------------------------------------
+  ! Save the old potential for time extrapolation in case of subcycling
+  !--------------------------------------------------------------------
   integer::i,ncache,ind,igrid,iskip,istart,ibound
-  integer,allocatable,dimension(:)::ind_grid
 
+  ! Loop over MPI domains and boundaries
   do ibound=1,nboundary+ncpu
      if(ibound<=ncpu)then
         ncache=numbl(ibound,ilevel)
@@ -102,24 +102,16 @@ subroutine save_phi_old(ilevel)
         ncache=numbb(ibound-ncpu,ilevel)
         istart=headb(ibound-ncpu,ilevel)
      end if
-     if(ncache>0)then
-        allocate(ind_grid(1:ncache))
-        ! Loop over level grids
-        igrid=istart
-        do i=1,ncache
-           ind_grid(i)=igrid
-           igrid=next(igrid)
-        end do
-        ! Loop over cells
+     ! Loop over grids by following the linked list
+     igrid=istart
+     do i=1,ncache
+        ! Loop over cells in the current grid
         do ind=1,twotondim
            iskip=ncoarse+(ind-1)*ngridmax
-           ! save phi
-           do i=1,ncache
-              phi_old(ind_grid(i)+iskip)=phi(ind_grid(i)+iskip)
-           end do
+           phi_old(igrid+iskip)=phi(igrid+iskip)
         end do
-        deallocate(ind_grid)
-     end if
+        igrid=next(igrid)
+      end do 
   end do
 
 end subroutine save_phi_old


### PR DESCRIPTION
Rewrite save_phi_old so that the grid index is used right away instead of stored in an array which is allocated inside the loop over cpus. Allocate/deallocate is a slow operation and inside a loop can lead to memory performance issues. Here especially it could become expensive when ncpu is large.