### PR TITLE
OpenMP: add variables for nthr + fix

### DIFF
--- a/amr/amr_commons.f90
+++ b/amr/amr_commons.f90
@@ -32,6 +32,7 @@ module amr_commons
 
   ! MPI variables
   integer::ncpu,ndomain,myid,overload=1
+  integer::nthr=1  ! OpenMP number of threads
 
   ! Friedman model variables
   integer::n_frw

--- a/amr/nbors_utils.f90
+++ b/amr/nbors_utils.f90
@@ -23,7 +23,8 @@ subroutine get3cubefather(ind_cell_father,nbors_father_cells,&
   integer,dimension(1:nvector,1:twotondim),save::nbors_grids_ok
   logical::oups
 
-!$omp threadprivate(ix,iy,iz,iix,iiy,iiz,pos,ind_grid_father,ind_grid_ok,nbors_father_ok,nbors_grids_ok)
+!$omp threadprivate(ix,iy,iz,iix,iiy,iiz)
+!$omp threadprivate(pos,ind_grid_father,ind_grid_ok,nbors_father_ok,nbors_grids_ok)
 
   nxny=nx*ny
 
@@ -225,6 +226,7 @@ subroutine get3cubepos(ind_grid,ind,nbors_father_cells,nbors_father_grids,ng)
   integer,dimension(1:threetondim),save::lll_loc,mmm_loc
 
 !$omp threadprivate(ind_grid1,ind_grid2,ind_grid3,nbors_grids)
+!$omp threadprivate(lll_loc,mmm_loc)
 
   ! fetch magic indices
   lll_loc = lll(:,ind)

--- a/amr/ramses.f90
+++ b/amr/ramses.f90
@@ -1,7 +1,7 @@
 program ramses
   implicit none
 
-  ! Set myid, ncpu and initialize MPI
+  ! Set myid, ncpu and initialize MPI and OpenMP
   call initialize_mpi
 
   ! Read run parameters
@@ -19,22 +19,43 @@ end program ramses
 
 
 subroutine initialize_mpi
-  use amr_commons, only:myid,ncpu
+  use amr_commons, only:myid,ncpu,nthr
   use mpi_mod
+#ifdef OPENMP
+  use omp_lib
+#endif
   implicit none
 #ifndef WITHOUTMPI
-  integer::ierr
+  integer::ierr,info
 #endif
+integer::mythr
 
   ! MPI initialization
 #ifdef WITHOUTMPI
   ncpu=1
   myid=1
 #else
+#ifdef OPENMP
+  call MPI_INIT_THREAD(MPI_THREAD_SERIALIZED,info,ierr)
+  if(info<MPI_THREAD_SERIALIZED) then
+      write(*,*) 'Error: MPI_THREAD_SERIALIZED is not supported in current MPI library'
+      stop
+  end if
+#else
   call MPI_INIT(ierr)
+#endif
   call MPI_COMM_RANK(MPI_COMM_WORLD,myid,ierr)
   call MPI_COMM_SIZE(MPI_COMM_WORLD,ncpu,ierr)
   myid=myid+1 ! Careful with this...
+#endif
+
+#ifdef OPENMP
+!$omp parallel private(mythr)
+  mythr=omp_get_thread_num()+1
+  if(mythr==1) then
+     nthr=omp_get_num_threads()
+  end if
+!$omp end parallel
 #endif
 
 end subroutine initialize_mpi

--- a/amr/read_params.f90
+++ b/amr/read_params.f90
@@ -47,7 +47,11 @@ subroutine read_params
   write(*,*)'       written by Romain Teyssier (Princeton University)       '
   write(*,*)'           (c) CEA 1999-2007, UZH 2008-2021, PU 2022           '
   write(*,*)' '
+#ifdef OPENMP
+  write(*,'(" Working with nproc = ",I4," and nthr = ",I3," for ndim = ",I1)')ncpu,nthr,ndim
+#else
   write(*,'(" Working with nproc = ",I5," for ndim = ",I1)')ncpu,ndim
+#endif
   ! Check nvar is not too small
 #ifdef SOLVERhydro
   write(*,'(" Using solver = hydro with nvar = ",I2)')nvar

--- a/hydro/godunov_fine.f90
+++ b/hydro/godunov_fine.f90
@@ -514,6 +514,7 @@ subroutine godfine1(ind_grid,ncache,ilevel)
 
 !$omp threadprivate(nbors_father_cells,nbors_father_grids,ibuffer_father,u1,u2,req2,peq2)
 !$omp threadprivate(uloc,gloc,ploc,req_loc,peq_loc,flux,tmp,ok)
+!$omp threadprivate(igrid_nbor,ind_cell,ind_buffer,ind_exist,ind_nexist)
 
   oneontwotondim = 1d0/dble(twotondim)
 


### PR DESCRIPTION
* Retrieve the number of openMP threads and print info to log
* Initialize MPI so it knows about the threads
* Fix missing threadprivate variables lll and mmm after merging in a refactoring from dev branch
* Add missing threadprivate variables in godfine1