### PR TITLE
OpenMP: hydro on unigrid

### DIFF
--- a/hydro/courant_fine.f90
+++ b/hydro/courant_fine.f90
@@ -44,6 +44,8 @@ subroutine courant_fine(ilevel)
 
   ! Loop over active grids by vector sweeps
   ncache=active(ilevel)%ngrid
+!$omp parallel do private(ngrid,iskip,nleaf,dt_lev) &
+!$omp & reduction(+:mass_loc,ekin_loc,eint_loc) reduction(MIN:dt_loc)
   do igrid=1,ncache,nvector
      ngrid=MIN(nvector,ncache-igrid+1)
      do i=1,ngrid

--- a/hydro/godunov_fine.f90
+++ b/hydro/godunov_fine.f90
@@ -59,6 +59,7 @@ subroutine set_unew(ilevel)
   if(verbose)write(*,111)ilevel
 
   ! Set unew to uold for myid cells
+!$omp parallel do private(iskip,ivar,i,d,u,v,w,e)
   do ind=1,twotondim
      iskip=ncoarse+(ind-1)*ngridmax
      do ivar=1,nvar
@@ -93,6 +94,7 @@ subroutine set_unew(ilevel)
   end do
 
   ! Set unew to 0 for virtual boundary cells
+!$omp parallel do private(ind,iskip,ivar,i)
   do icpu=1,ncpu
   do ind=1,twotondim
      iskip=ncoarse+(ind-1)*ngridmax
@@ -160,6 +162,7 @@ subroutine set_uold(ilevel)
   dx=0.5d0**ilevel*scale
 
   ! Set uold to unew for myid cells
+!$omp parallel do private(iskip,ivar,i,d,u,v,w,e_kin,e_cons,e_prim,e_trunc,div)
   do ind=1,twotondim
      iskip=ncoarse+(ind-1)*ngridmax
 
@@ -785,6 +788,7 @@ subroutine godfine1(ind_grid,ncache,ilevel)
   !--------------------------------------
   ! Conservative update at level ilevel-1
   !--------------------------------------
+  if(levelmin.ne.nlevelmax)then
   ! Loop over dimensions
   do idim=1,ndim
      i0=0; j0=0; k0=0
@@ -812,6 +816,7 @@ subroutine godfine1(ind_grid,ncache,ilevel)
         do j3=j3min,j3max-j0
         do i3=i3min,i3max-i0
            do i=1,nb_noneigh
+!$omp atomic update
               unew(ind_buffer(i),ivar)=unew(ind_buffer(i),ivar) &
                    & -flux(ind_cell(i),i3,j3,k3,ivar,idim)*oneontwotondim
            end do
@@ -836,6 +841,7 @@ subroutine godfine1(ind_grid,ncache,ilevel)
      do j3=j3min,j3max-j0
      do i3=i3min,i3max-i0
         do i=1,nb_noneigh
+!$omp atomic update
            enew(ind_buffer(i))=enew(ind_buffer(i)) &
                 & -tmp(ind_cell(i),i3,j3,k3,2,idim)*oneontwotondim
         end do
@@ -864,6 +870,7 @@ subroutine godfine1(ind_grid,ncache,ilevel)
         do j3=j3min+j0,j3max
         do i3=i3min+i0,i3max
            do i=1,nb_noneigh
+!$omp atomic update
               unew(ind_buffer(i),ivar)=unew(ind_buffer(i),ivar) &
                    & +flux(ind_cell(i),i3+i0,j3+j0,k3+k0,ivar,idim)*oneontwotondim
            end do
@@ -877,6 +884,7 @@ subroutine godfine1(ind_grid,ncache,ilevel)
      do j3=j3min+j0,j3max
      do i3=i3min+i0,i3max
         do i=1,nb_noneigh
+!$omp atomic update
            divu(ind_buffer(i))=divu(ind_buffer(i)) &
                 & +tmp(ind_cell(i),i3+i0,j3+j0,k3+k0,1,idim)*oneontwotondim
         end do
@@ -888,6 +896,7 @@ subroutine godfine1(ind_grid,ncache,ilevel)
      do j3=j3min+j0,j3max
      do i3=i3min+i0,i3max
         do i=1,nb_noneigh
+!$omp atomic update
            enew(ind_buffer(i))=enew(ind_buffer(i)) &
                 & +tmp(ind_cell(i),i3+i0,j3+j0,k3+k0,2,idim)*oneontwotondim
         end do
@@ -898,5 +907,6 @@ subroutine godfine1(ind_grid,ncache,ilevel)
 
   end do
   ! End loop over dimensions
+  endif
 
 end subroutine godfine1

--- a/hydro/godunov_fine.f90
+++ b/hydro/godunov_fine.f90
@@ -24,6 +24,7 @@ subroutine godunov_fine(ilevel)
 
   ! Loop over active grids by vector sweeps
   ncache=active(ilevel)%ngrid
+!$omp parallel do private(ngrid,i)
   do igrid=1,ncache,nvector
      ngrid=MIN(nvector,ncache-igrid+1)
      do i=1,ngrid

--- a/hydro/interpol_hydro.f90
+++ b/hydro/interpol_hydro.f90
@@ -23,6 +23,7 @@ subroutine upload_fine(ilevel)
 
   ! Loop over active grids by vector sweeps
   ncache=active(ilevel)%ngrid
+!$omp parallel do private(ngrid,i,ind,iskip,nsplit,icell)
   do igrid=1,ncache,nvector
      ngrid=MIN(nvector,ncache-igrid+1)
      do i=1,ngrid


### PR DESCRIPTION
This PR adds full openMP support for hydro simulations on a uniform grid, as benchmarked by the sedov3d benchmark.
OpenMP is added to:
* main loop of godunov solver
* take into account atomic updates in the case of AMR in godfine1
* main loops of set_uold and set_unew
* main loop of courant_fine
* main loop of upload_fine

For a 1024^3 sedov benchmark, a speedup can be observed from 64 nodes when using 8 threads (as measured on MeluXina).
The main advantage for using openMP in unigrid hydro simulation comes from the major reduction in memory requirements to store the computation domain, due to there being less boundary grids. For example, on 32 nodes with 4 threads the memory required is only a third of what is was with mpi-only.

This work was done is the context of the SPACE CoE and based in part on the yOMP version of Ramses developed by San Han.