### PR TITLE
set npartmax to 0 if pic is false

### DIFF
--- a/amr/read_params.f90
+++ b/amr/read_params.f90
@@ -430,7 +430,7 @@ subroutine read_amr_params(namelist_unit,nml_ok)
 
    if(pic .and. npartmax==0) then
       npartmax=int(nparttot/int(ncpu,kind=8),kind=4)
-   else if (.not. pic) then 
+   else if (.not. pic) then
       npartmax=0
    end if
 

--- a/amr/read_params.f90
+++ b/amr/read_params.f90
@@ -427,9 +427,12 @@ subroutine read_amr_params(namelist_unit,nml_ok)
          ngridmax=int(ngridtot/int(ncpu,kind=8),kind=4)
       endif
    end if
-   if(npartmax==0)then
+
+   if(pic .and. npartmax==0) then
       npartmax=int(nparttot/int(ncpu,kind=8),kind=4)
-   endif
+   else if (.not. pic) then 
+      npartmax=0
+   end if
 
    if(nlevelmax>MAXLEVEL)then
       write(*,*) 'Error: nlevelmax>MAXLEVEL'

--- a/tests/hydro/sod-tube/sod-tube.nml
+++ b/tests/hydro/sod-tube/sod-tube.nml
@@ -9,6 +9,7 @@ nsubcycle=3*1,2
 levelmin=3
 levelmax=10
 ngridmax=2000
+nparttot=1 ! This parameter is useless because pic is false but the test should pass anyway.
 nexpand=1
 boxlen=1.0
 /


### PR DESCRIPTION
This fixes #149.

Sod tube test modified to check that combinaison of parameters.