### PR TITLE
Fix nlevelmax_sink not working as intended

### DIFF
--- a/doc/wiki/Sinks.md
+++ b/doc/wiki/Sinks.md
@@ -44,7 +44,7 @@ The block named `&SINK_PARAMS` contains the parameters related to the sink parti
 | `epsilon_kin`         | `float`      | `1.0`         | Kinetic feedback coupling efficiency
 | `kin_mass_loading`    | `float`      | `100.`        | Kinetic feedback mass loading
 | `cone_opening`        | `float`      | `180.`        | Opening angle of the cone through which momentum feedback proceeds
-| `nlevelmax_sink`      | `integer`    | `0`           | Allow sinks to form on a level that is lower than what is set by nlevelmax. This is useful in zoom similations where nlevelmax is set to a high value but in the first phase refinement is limited to only a few levels. nlevelmax_sink should be set to the maximum allowed refinement level.
+| `nlevelmax_sink`      | `integer`    | `0`           | Allow sinks to form on a level that is lower than what is set by nlevelmax. This is useful in zoom simulations where nlevelmax is set to a high value but in the first phase refinement is limited to only a few levels. nlevelmax_sink should be set to the maximum allowed refinement level.
 
 
 

--- a/doc/wiki/Sinks.md
+++ b/doc/wiki/Sinks.md
@@ -44,6 +44,7 @@ The block named `&SINK_PARAMS` contains the parameters related to the sink parti
 | `epsilon_kin`         | `float`      | `1.0`         | Kinetic feedback coupling efficiency
 | `kin_mass_loading`    | `float`      | `100.`        | Kinetic feedback mass loading
 | `cone_opening`        | `float`      | `180.`        | Opening angle of the cone through which momentum feedback proceeds
+| `nlevelmax_sink`      | `integer`    | `0`           | Allow sinks to form on a level that is lower than what is set by nlevelmax. This is useful in zoom similations where nlevelmax is set to a high value but in the first phase refinement is limited to only a few levels. nlevelmax_sink should be set to the maximum allowed refinement level.
 
 
 

--- a/pm/flag_formation_sites.f90
+++ b/pm/flag_formation_sites.f90
@@ -9,7 +9,7 @@ subroutine flag_formation_sites
   use clfind_commons
   use hydro_commons, only:uold
   use hydro_parameters, only:smallr
-  use pm_parameters, only:mass_halo_AGN,mass_clump_AGN
+  use pm_parameters, only:mass_halo_AGN,mass_clump_AGN,nlevelmax_sink
   use constants, only: pi, twopi, M_sun
   use mpi_mod
   implicit none
@@ -40,7 +40,7 @@ subroutine flag_formation_sites
   period(3)=(nz==1)
 
   ! Grid spacing and physical scales
-  dx=0.5D0**nlevelmax
+  dx=0.5D0**nlevelmax_sink
   nx_loc=(icoarse_max-icoarse_min+1)
   scale=boxlen/dble(nx_loc)
   dx_min=dx*scale
@@ -66,7 +66,7 @@ subroutine flag_formation_sites
         pos(1,1:3)=xsink(j,1:3)
         call cmp_cpumap(pos,cc,1)
         if (cc(1) .eq. myid)then
-           call get_cell_index(cell_index,cell_levl,pos,nlevelmax,1)
+           call get_cell_index(cell_index,cell_levl,pos,nlevelmax_sink,1)
            global_peak_id=flag2(cell_index(1))
            if(global_peak_id.NE.0)then
               call get_local_peak_id(global_peak_id,local_peak_id)
@@ -159,7 +159,7 @@ subroutine flag_formation_sites
            pos(1,1:3)=peak_pos(jj,1:3)
            call cmp_cpumap(pos,cc,1)
            if (cc(1) .eq. myid)then
-              call get_cell_index(cell_index,cell_levl,pos,nlevelmax,1)
+              call get_cell_index(cell_index,cell_levl,pos,nlevelmax_sink,1)
               ! Allow sink formation only inside zoom region
               if(ivar_refine>0)then
                  if(uold(cell_index(1),ivar_refine)/max(uold(cell_index(1),1),smallr)>var_cut_refine)then
@@ -201,7 +201,7 @@ subroutine flag_formation_sites
            pos(1,1:3)=peak_pos(jj,1:3)
            call cmp_cpumap(pos,cc,1)
            if (cc(1) .eq. myid)then
-              call get_cell_index(cell_index,cell_levl,pos,nlevelmax,1)
+              call get_cell_index(cell_index,cell_levl,pos,nlevelmax_sink,1)
               flag2(cell_index(1))=jj
               if(verbose)write(*,*)'cpu ',myid,' produces a new sink for clump number ',jj+ipeak_start(myid)
            end if
@@ -497,13 +497,13 @@ subroutine compute_clump_properties_round2
         end do
 
         ! Properties for regions close to peak (4 cells away)
-        if (((xpeak(1)-xcell(1))**2.+(xpeak(2)-xcell(2))**2.+(xpeak(3)-xcell(3))**2.) .LE. 16.*volume(nlevelmax)**(2./3.)/aexp**2)then
+        if (((xpeak(1)-xcell(1))**2.+(xpeak(2)-xcell(2))**2.+(xpeak(3)-xcell(3))**2.) .LE. 16.*volume(nlevelmax_sink)**(2./3.)/aexp**2)then
            clump_mass4(peak_nr)=clump_mass4(peak_nr)+d*vol
         endif
 
         ! Properties for regions close to peak (4 cells away)
         if(mass_star_AGN>0)then
-           if (((xpeak(1)-xcell(1))**2.+(xpeak(2)-xcell(2))**2.+(xpeak(3)-xcell(3))**2.) .LE. 16.*volume(nlevelmax)**(2./3.)/aexp**2)then
+           if (((xpeak(1)-xcell(1))**2.+(xpeak(2)-xcell(2))**2.+(xpeak(3)-xcell(3))**2.) .LE. 16.*volume(nlevelmax_sink)**(2./3.)/aexp**2)then
               clump_star4(peak_nr)=clump_star4(peak_nr)+rho_star*vol
            endif
         endif
@@ -608,6 +608,7 @@ subroutine trim_clumps
 #if NDIM==3
   use amr_commons
   use clfind_commons
+  use pm_parameters, only:nlevelmax_sink
   use pm_commons, only:ir_cloud
   implicit none
 
@@ -636,7 +637,7 @@ subroutine trim_clumps
   call units(scale_l,scale_t,scale_d,scale_v,scale_nH,scale_T2)
 
   ! Mesh spacing in max level
-  dx=0.5D0**nlevelmax
+  dx=0.5D0**nlevelmax_sink
   nx_loc=(icoarse_max-icoarse_min+1)
   skip_loc(1)=dble(icoarse_min)
   skip_loc(2)=dble(jcoarse_min)
@@ -774,6 +775,7 @@ end subroutine jacobi
 subroutine surface_int
   use amr_commons
   use hydro_commons
+  use pm_parameters, only:nlevelmax_sink
   use pm_commons
   use clfind_commons
   use poisson_commons
@@ -794,7 +796,7 @@ subroutine surface_int
   do ipart=1,ntest
      ip=ip+1
      ilevel=levp(testp_sort(ipart))
-     if (verbose.and.ilevel/=nlevelmax)print*,'not all particles in max level',ilevel
+     if (verbose.and.ilevel/=nlevelmax_sink)print*,'not all particles in max sink level',ilevel
      next_level=0
      if(ipart<ntest)next_level=levp(testp_sort(ipart+1))
      ind_cell(ip)=icellp(testp_sort(ipart))
@@ -822,6 +824,7 @@ end subroutine surface_int
 #if NDIM==3
 subroutine surface_int_np(ind_cell,np,ilevel)
   use amr_commons
+  use pm_parameters, only:nlevelmax_sink
 #ifdef SOLVERmhd
   use clfind_commons, ONLY: center_of_mass,Psurf,MagPsurf,MagTsurf
 #else
@@ -1062,7 +1065,7 @@ subroutine surface_int_np(ind_cell,np,ilevel)
   !===================================
   ! generate neighbors at level ilevel+1
   !====================================
-  if(ilevel<nlevelmax)then
+  if(ilevel<nlevelmax_sink)then
      ! Generate 4x4x4 neighboring cells at level ilevel+1
      do k3=0,3
         do j3=0,3

--- a/pm/rho_fine.f90
+++ b/pm/rho_fine.f90
@@ -325,6 +325,7 @@ end subroutine rho_from_current_level
 subroutine cic_amr(ind_cell,ind_part,ind_grid_part,x0,ng,np,ilevel)
   use amr_commons
   use pm_commons
+  use pm_parameters, only:nlevelmax_sink
   use poisson_commons
   use hydro_commons, ONLY: mass_sph
   implicit none
@@ -617,7 +618,7 @@ subroutine cic_amr(ind_cell,ind_part,ind_grid_part,x0,ng,np,ilevel)
 
      ! Always refine sinks to the maximum level
      ! by setting particle number density above m_refine(ilevel)
-     if(sink_refine)then
+     if(sink_refine.and.(ilevel<=nlevelmax_sink))then
         do j=1,np
            if ( is_cloud(fam(j)) ) then
               ! if (direct_force_sink(-1*idp(ind_part(j))))then

--- a/tests/sink/center-SN/center-SN.nml
+++ b/tests/sink/center-SN/center-SN.nml
@@ -13,7 +13,7 @@ poisson=.true.
 pic=.true.
 sink=.true.
 stellar=.true.
-nsubcycle=1,1
+nsubcycle=1
 verbose=.false.
 /
 
@@ -33,10 +33,10 @@ p_region=3300.1987634209013
 
 &AMR_PARAMS
 levelmin=6
-levelmax=7
+levelmax=8
 ngridmax=350000
 npartmax=50000
-nexpand=4,4,4,4,4
+nexpand=4
 boxlen=250. ! pc
 /
 
@@ -67,7 +67,7 @@ units_length  = 3.08567758128200d18 ! 1 pc
 /
 
 &REFINE_PARAMS
-jeans_refine=8,8,8
+jeans_refine=8
 interpol_type=0
 interpol_var=1
 sink_refine=.true.
@@ -79,6 +79,7 @@ gravity_type=0
 
 
 &SINK_PARAMS
+nlevelmax_sink=7
 create_sinks=.false.
 nsinkmax=10
 mass_sink_seed=1 ! in M_sun

--- a/tests/sink/spawning/spawning.nml
+++ b/tests/sink/spawning/spawning.nml
@@ -5,19 +5,19 @@ hydro=.true.
 poisson=.true.
 pic=.true.
 sink=.true.
-nsubcycle=2,2,2
+nsubcycle=2
 /
 
 &AMR_PARAMS
 levelmin=6
-levelmax=7
+levelmax=8
 ngridmax=500000
 npartmax=100000
 boxlen=4
 /
 
 &REFINE_PARAMS
-jeans_refine=6,6,6
+jeans_refine=6
 interpol_type=0
 interpol_var=1
 sink_refine=.true.
@@ -81,6 +81,7 @@ turb_min_rho=1e-10 ! Minimum density for turbulence
 /
 
 &SINK_PARAMS
+nlevelmax_sink=7
 create_sinks=.true.
 check_energies=.false.
 nsinkmax=100

--- a/tests/sink/stellar-HII/stellar-HII.nml
+++ b/tests/sink/stellar-HII/stellar-HII.nml
@@ -14,7 +14,7 @@ rt=.true.
 pic=.true.
 sink=.true.
 stellar=.true.
-nsubcycle=1,1
+nsubcycle=1
 verbose=.false.
 /
 
@@ -34,10 +34,10 @@ p_region=3300.1987634209013
 
 &AMR_PARAMS
 levelmin=6
-levelmax=7
+levelmax=8
 ngridmax=350000
 npartmax=50000
-nexpand=4,4,4,4,4
+nexpand=4
 boxlen=250. ! pc
 /
 
@@ -68,7 +68,7 @@ units_length  = 3.08567758128200d18 ! 1 pc
 /
 
 &REFINE_PARAMS
-jeans_refine=8,8,8
+jeans_refine=8
 interpol_type=0
 interpol_var=1
 sink_refine=.true.
@@ -79,6 +79,7 @@ gravity_type=0
 /
 
 &SINK_PARAMS
+nlevelmax_sink=7
 create_sinks=.false.
 nsinkmax=10
 mass_sink_seed=1 ! in M_sun

--- a/tests/sink/stellar-spawn/stellar-spawn.nml
+++ b/tests/sink/stellar-spawn/stellar-spawn.nml
@@ -12,7 +12,7 @@ poisson=.true.
 pic=.true.
 sink=.true.
 stellar=.true.
-nsubcycle=1,1
+nsubcycle=1
 verbose=.false.
 /
 
@@ -32,10 +32,10 @@ p_region=3300.1987634209013
 
 &AMR_PARAMS
 levelmin=6
-levelmax=7
+levelmax=8
 ngridmax=350000
 npartmax=2200
-nexpand=4,4,4,4,4
+nexpand=4
 boxlen=250. ! pc
 /
 
@@ -66,7 +66,7 @@ units_length  = 3.08567758128200d18 ! 1 pc
 /
 
 &REFINE_PARAMS
-jeans_refine=8,8,8
+jeans_refine=8
 interpol_type=0
 interpol_var=1
 sink_refine=.true.
@@ -77,6 +77,7 @@ gravity_type=0
 /
 
 &SINK_PARAMS
+nlevelmax_sink=7
 create_sinks=.false.
 nsinkmax=1
 mass_sink_seed=1 ! in M_sun


### PR DESCRIPTION
Patrick Hennebelle reported that sinks were not forming properly when using this. He traced it to a problem with clump_mass4. I looked further into it and found places where nlevelmax should be replaced by nlevelmax_sink.

I also fixed the issue were nlevelmax_sink could not be combined with sink_refine.

I updated the sink_spawning test namelist to catch this issue.
I verified there are no issues for sink feedback, by adding nlevelmax_sink to the tests that cover these. 