### PR TITLE
Overhaul of compiler flags in Makefile

### DIFF
--- a/bin/Makefile
+++ b/bin/Makefile
@@ -86,52 +86,72 @@ ifeq ($(LIGHT_MPI_COMM), 1)
    DEFINES += -DLIGHT_MPI_COMM
 endif
 #############################################################################
-# Fortran compiler options and directives
+# Compiler command for regular compilation (mpi or serial)
+F90 =
+# Serial compiler command and flags for helper files
+FC =
+# Base compiler flags for compilation
+FFLAGS_BASE =
+# Compiler flags for optimization
+FFLAGS_OPT = -O3 -flto -fwhole-program
+# Compiler flags for linking
+LDFLAGS = -flto -fwhole-program
+# Load presets for MPIF90 and FFLAGS_OPT for specified machine
+-include Makefile.machines
 
 # GNU compiler (gfortran)
 ifeq ($(COMPILER),GNU)
-   FFLAGS = -cpp $(DEFINES)
+   # set compiler commands
    ifeq ($(MPI),1)
       F90 = $(MPIF90)
-      FC = gfortran
    else
       F90 = gfortran
-      FC = gfortran
-      FFLAGS += -DWITHOUTMPI
    endif
-   F90 += -ffree-line-length-none -fimplicit-none
-   FC += -ffree-line-length-none -fimplicit-none
+   FC = gfortran -ffree-line-length-none -fimplicit-none
+   FFLAGS_BASE += -ffree-line-length-none -fimplicit-none
+   # add preprocessor macro definitions to compilation flags
+   FFLAGS_BASE += -cpp $(DEFINES)
+   ifeq ($(MPI),0)
+      FFLAGS_BASE += -DWITHOUTMPI
+   endif
+   # Flags for coverage calculation (resets optimization flags) 
    ifeq ($(GCOV),1)
-         F90 += -O0 -fprofile-arcs -ftest-coverage
-   else
-      ifeq ($(DEBUG),1)
-         F90 += -g -O0 -fbacktrace -fbounds-check -Wuninitialized -Wall
-         FFLAGS += -ffpe-trap=zero,underflow,overflow,invalid -finit-real=nan
-      else
-         F90 += -O3 -flto -fwhole-program
-      endif
+      FFLAGS_BASE += -fprofile-arcs -ftest-coverage
+      LDFLAGS += -fprofile-arcs -ftest-coverage
+      FFLAGS_OPT = -O0
+   else ifeq ($(DEBUG),1)
+      # Flags for debugging (resets optimization flags) 
+      FFLAGS_BASE += -g -fbacktrace -fbounds-check -Wuninitialized -Wall
+      FFLAGS_BASE += -ffpe-trap=zero,underflow,overflow,invalid -finit-real=nan
+      LDFLAGS += -g
+      FFLAGS_OPT = -O0
    endif
 endif
 
 # Intel compiler
 ifeq ($(COMPILER),INTEL)
-   FFLAGS = -cpp $(DEFINES)
+   # set compiler commands
    ifeq ($(MPI),1)
       F90 = $(MPIF90)
-      FC = ifort
-      FFLAGS += -DNOSYSTEM
    else
       F90 = ifort
-      FC = ifort
-      FFLAGS += -DWITHOUTMPI
    endif
-   F90 += -fp-model source
-   FC += -fp-model source
-   ifeq ($(DEBUG),1)
-      F90 += -warn all -O0 -g -traceback -check bounds
-      FFLAGS += -fpe0 -ftrapuv -init=zero -init=snan -init=arrays
+   FC = ifort -fp-model source
+   FFLAGS_BASE += -fp-model source
+   FFLAGS_OPT += -O3 -ipo -inline-forceinline
+   # add preprocessor macro definitions to compilation flags
+   FFLAGS_BASE += -cpp $(DEFINES)
+   ifeq ($(MPI),1)
+      FFLAGS_BASE += -DNOSYSTEM
    else
-      F90 += -O3 -ipo -inline-forceinline
+      FFLAGS_BASE += -DWITHOUTMPI
+   endif
+   # Flags for debugging (resets optimization flags) 
+   ifeq ($(DEBUG),1)
+      FFLAGS_BASE += -g -traceback -check bounds -warn all
+      FFLAGS_BASE += -fpe0 -ftrapuv -init=zero -init=snan -init=arrays
+      LDFLAGS += -g -traceback
+      FFLAGS_OPT = -O0
    endif
 endif
 
@@ -233,11 +253,11 @@ ATON_OBJ = observe.o init_radiation.o rad_init.o rad_boundary.o rad_stars.o \
            rad_backup.o ../aton/atonlib/libaton.a
 #############################################################################
 ramses:	$(MODOBJ) $(AMRLIB) ramses.o
-	$(F90) $(MODOBJ) $(AMRLIB) ramses.o -o $(EXEC)$(NDIM)d $(LIBS)
+	$(F90) $(LDFLAGS) $(MODOBJ) $(AMRLIB) ramses.o -o $(EXEC)$(NDIM)d $(LIBS)
 	rm write_makefile.f90
 	rm write_patch.f90
 ramses_aton: $(MODOBJ) $(ATON_MODOBJ) $(AMRLIB) $(ATON_OBJ) ramses.o
-	$(F90) $(MODOBJ) $(ATON_MODOBJ) $(AMRLIB) $(ATON_OBJ) ramses.o \
+	$(F90) $(LDFLAGS) $(MODOBJ) $(ATON_MODOBJ) $(AMRLIB) $(ATON_OBJ) ramses.o \
 		-o $(EXEC)$(NDIM)d $(LIBS) $(LIBCUDA)
 	rm write_makefile.f90
 	rm write_patch.f90
@@ -253,9 +273,9 @@ write_patch.o: FORCE
 	../utils/scripts/cr_write_patch.sh $(PATCH)
 	$(FC) -O0 -c write_patch.f90 -o $@
 %.o:%.F
-	$(F90) $(FFLAGS) -c $^ -o $@ $(LIBS_OBJ) $(LIBS_OBJ_TURB)
+	$(F90) $(FFLAGS_BASE) $(FFLAGS_OPT) -c $^ -o $@ $(LIBS_OBJ) $(LIBS_OBJ_TURB)
 %.o:%.f90
-	$(F90) $(FFLAGS) -c $^ -o $@ $(LIBS_OBJ) $(LIBS_OBJ_TURB)
+	$(F90) $(FFLAGS_BASE) $(FFLAGS_OPT) -c $^ -o $@ $(LIBS_OBJ) $(LIBS_OBJ_TURB)
 FORCE:
 #############################################################################
 clean:

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -117,14 +117,14 @@ ifeq ($(COMPILER),GNU)
    endif
    # link-time optimization accross files
    LDFLAGS += -flto -fwhole-program
-   FFLAGS_OPT += -flto -fwhole-program 
-   # Flags for coverage calculation (resets optimization flags) 
+   FFLAGS_OPT += -flto -fwhole-program
+   # Flags for coverage calculation (resets optimization flags)
    ifeq ($(GCOV),1)
       FFLAGS_BASE += -fprofile-arcs -ftest-coverage
       LDFLAGS = -fprofile-arcs -ftest-coverage
       FFLAGS_OPT = -O0
    else ifeq ($(DEBUG),1)
-      # Flags for debugging (resets optimization flags) 
+      # Flags for debugging (resets optimization flags)
       FFLAGS_BASE += -g -fbacktrace -fbounds-check -Wuninitialized -Wall
       FFLAGS_BASE += -ffpe-trap=zero,underflow,overflow,invalid -finit-real=nan
       LDFLAGS = -g
@@ -152,7 +152,7 @@ ifeq ($(COMPILER),INTEL)
    # link-time optimization and inlining accross files
    LDFLAGS += -ipo -inline-forceinline
    FFLAGS_OPT += -ipo -inline-forceinline
-   # Flags for debugging (resets optimization flags) 
+   # Flags for debugging (resets optimization flags)
    ifeq ($(DEBUG),1)
       FFLAGS_BASE += -g -traceback -check bounds -warn all
       FFLAGS_BASE += -fpe0 -ftrapuv -init=zero -init=snan -init=arrays

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -9,6 +9,8 @@ DEBUG = 0
 GCOV = 0
 # Compiler flavor: GNU or INTEL
 COMPILER = GNU
+# Target cluster, to set cluster specific optimisation flags (see Makefile.machines)
+MACHINE = generic
 # Size of vector cache
 NVECTOR = 32
 # Number of dimensions
@@ -25,7 +27,6 @@ RT = 0
 USE_TURB = 0
 # Use MPI? 1=Yes, 0=No
 MPI = 0
-MPIF90 = mpif90
 # Root name of executable
 EXEC = ramses
 # Number of additional energies
@@ -97,7 +98,7 @@ FFLAGS_OPT = -O3 -flto -fwhole-program
 # Compiler flags for linking
 LDFLAGS = -flto -fwhole-program
 # Load presets for MPIF90 and FFLAGS_OPT for specified machine
--include Makefile.machines
+-include clusters.mk
 
 # GNU compiler (gfortran)
 ifeq ($(COMPILER),GNU)

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -115,16 +115,19 @@ ifeq ($(COMPILER),GNU)
    ifeq ($(MPI),0)
       FFLAGS_BASE += -DWITHOUTMPI
    endif
+   # link-time optimization accross files
+   LDFLAGS += -flto -fwhole-program
+   FFLAGS_OPT += -flto -fwhole-program 
    # Flags for coverage calculation (resets optimization flags) 
    ifeq ($(GCOV),1)
       FFLAGS_BASE += -fprofile-arcs -ftest-coverage
-      LDFLAGS += -fprofile-arcs -ftest-coverage
+      LDFLAGS = -fprofile-arcs -ftest-coverage
       FFLAGS_OPT = -O0
    else ifeq ($(DEBUG),1)
       # Flags for debugging (resets optimization flags) 
       FFLAGS_BASE += -g -fbacktrace -fbounds-check -Wuninitialized -Wall
       FFLAGS_BASE += -ffpe-trap=zero,underflow,overflow,invalid -finit-real=nan
-      LDFLAGS += -g
+      LDFLAGS = -g
       FFLAGS_OPT = -O0
    endif
 endif
@@ -147,11 +150,14 @@ ifeq ($(COMPILER),INTEL)
    else
       FFLAGS_BASE += -DWITHOUTMPI
    endif
+   # link-time optimization and inlining accross files
+   LDFLAGS += -ipo -inline-level=3
+   FFLAGS_OPT += -ipo -inline-level=3
    # Flags for debugging (resets optimization flags) 
    ifeq ($(DEBUG),1)
       FFLAGS_BASE += -g -traceback -check bounds -warn all
       FFLAGS_BASE += -fpe0 -ftrapuv -init=zero -init=snan -init=arrays
-      LDFLAGS += -g -traceback
+      LDFLAGS = -g -traceback
       FFLAGS_OPT = -O0
    endif
 endif

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -94,9 +94,9 @@ FC =
 # Base compiler flags for compilation
 FFLAGS_BASE =
 # Compiler flags for optimization
-FFLAGS_OPT = -O3 -flto -fwhole-program
+FFLAGS_OPT = -O3
 # Compiler flags for linking
-LDFLAGS = -flto -fwhole-program
+LDFLAGS =
 # Load presets for MPIF90 and FFLAGS_OPT for specified machine
 -include clusters.mk
 
@@ -142,7 +142,6 @@ ifeq ($(COMPILER),INTEL)
    endif
    FC = ifort -fp-model source
    FFLAGS_BASE += -fp-model source
-   FFLAGS_OPT += -O3 -ipo -inline-forceinline
    # add preprocessor macro definitions to compilation flags
    FFLAGS_BASE += -cpp $(DEFINES)
    ifeq ($(MPI),1)
@@ -151,8 +150,8 @@ ifeq ($(COMPILER),INTEL)
       FFLAGS_BASE += -DWITHOUTMPI
    endif
    # link-time optimization and inlining accross files
-   LDFLAGS += -ipo -inline-level=3
-   FFLAGS_OPT += -ipo -inline-level=3
+   LDFLAGS += -ipo -inline-forceinline
+   FFLAGS_OPT += -ipo -inline-forceinline
    # Flags for debugging (resets optimization flags) 
    ifeq ($(DEBUG),1)
       FFLAGS_BASE += -g -traceback -check bounds -warn all

--- a/bin/clusters.mk
+++ b/bin/clusters.mk
@@ -9,34 +9,34 @@ endif
 
 ####### EuroHPC clusters #######
 
-# 
+#
 ifeq ($(MACHINE),discoverer)
    MPIF90 = mpif90
 endif
 
-# 
+#
 ifeq ($(MACHINE),karolina)
    MPIF90 = mpif90
 endif
 
-# 
+#
 ifeq ($(MACHINE),leonardo)
    MPIF90 = mpiifort
 endif
 
-# 
+#
 ifeq ($(MACHINE),lumi)
    MPIF90 = ftn
    # mismatch flag needed to circumvent MPI_ALLREDUCE error
    FFLAGS_BASE += -fallow-argument-mismatch
 endif
 
-# 
+#
 ifeq ($(MACHINE),marenostrum)
    MPIF90 = mpif90
 endif
 
-# 
+#
 ifeq ($(MACHINE),meluxina)
    MPIF90 = mpif90
    ifeq ($(COMPILER),GNU)
@@ -44,8 +44,7 @@ ifeq ($(MACHINE),meluxina)
    endif
 endif
 
-# 
+#
 ifeq ($(MACHINE),vega)
    MPIF90 = mpif90
 endif
-

--- a/bin/clusters.mk
+++ b/bin/clusters.mk
@@ -1,0 +1,51 @@
+#############################################################################
+# This part of the Makefile contains machine specific compiler options
+#############################################################################
+
+# Default "generic" cluster: no special tuning
+ifeq ($(MACHINE),generic)
+   MPIF90 = mpif90
+endif
+
+####### EuroHPC clusters #######
+
+# 
+ifeq ($(MACHINE),discoverer)
+   MPIF90 = mpif90
+endif
+
+# 
+ifeq ($(MACHINE),karolina)
+   MPIF90 = mpif90
+endif
+
+# 
+ifeq ($(MACHINE),leonardo)
+   MPIF90 = mpiifort
+endif
+
+# 
+ifeq ($(MACHINE),lumi)
+   MPIF90 = ftn
+   # mismatch flag needed to circumvent MPI_ALLREDUCE error
+   FFLAGS_BASE += -fallow-argument-mismatch
+endif
+
+# 
+ifeq ($(MACHINE),marenostrum)
+   MPIF90 = mpif90
+endif
+
+# 
+ifeq ($(MACHINE),meluxina)
+   MPIF90 = mpif90
+   ifeq ($(COMPILER),GNU)
+      FFLAGS_OPT += -march=znver3 -qopt-zmm-usage=high
+   endif
+endif
+
+# 
+ifeq ($(MACHINE),vega)
+   MPIF90 = mpif90
+endif
+

--- a/bin/clusters.mk
+++ b/bin/clusters.mk
@@ -40,7 +40,7 @@ endif
 ifeq ($(MACHINE),meluxina)
    MPIF90 = mpif90
    ifeq ($(COMPILER),GNU)
-      FFLAGS_OPT += -march=znver3 -qopt-zmm-usage=high
+      FFLAGS_OPT += -march=native
    endif
 endif
 


### PR DESCRIPTION
Separate compiler flags in the Makefile in 3 categories:
* FFLAGS_BASE: base compilation flags to make the code run in a specified mode
* FFLAGS_OPT: optimization compilation flags
* LDFLAGS: flags that need to be applied for both compilation and linking
F90 now contains only the pure compiler command, e.g. gfortran, ifort or their MPI versions.

Added a supplementary Makefile called clusters.mk for adding machine specific compiler flags. Moved the MPI compiler command MPIF90 to this file. Filled in the value of MPIF90 for 7/8 EuroHPC clusters. Optimization flags to be added later.

The parameters in clusters.mk will be loaded automatically by the Makefile when setting the new parameter MACHINE at the top. DEBUG and COV options will overwrite optimisation flags set in clusters.mk.
