### PR TITLE
remove flto as a default compiler flag to fix compilation on mac

### DIFF
--- a/bin/Makefile
+++ b/bin/Makefile
@@ -115,9 +115,6 @@ ifeq ($(COMPILER),GNU)
    ifeq ($(MPI),0)
       FFLAGS_BASE += -DWITHOUTMPI
    endif
-   # link-time optimization accross files
-   LDFLAGS += -flto -fwhole-program
-   FFLAGS_OPT += -flto -fwhole-program
    # Flags for coverage calculation (resets optimization flags)
    ifeq ($(GCOV),1)
       FFLAGS_BASE += -fprofile-arcs -ftest-coverage
@@ -149,9 +146,6 @@ ifeq ($(COMPILER),INTEL)
    else
       FFLAGS_BASE += -DWITHOUTMPI
    endif
-   # link-time optimization and inlining accross files
-   LDFLAGS += -ipo -inline-forceinline
-   FFLAGS_OPT += -ipo -inline-forceinline
    # Flags for debugging (resets optimization flags)
    ifeq ($(DEBUG),1)
       FFLAGS_BASE += -g -traceback -check bounds -warn all

--- a/bin/clusters.mk
+++ b/bin/clusters.mk
@@ -12,16 +12,33 @@ endif
 #
 ifeq ($(MACHINE),discoverer)
    MPIF90 = mpif90
+   ifeq ($(COMPILER),GNU)
+      FFLAGS_OPT += -march=native
+      # link-time optimization accross files
+      LDFLAGS += -flto -fwhole-program
+      FFLAGS_OPT += -flto -fwhole-program
+   endif
 endif
 
 #
 ifeq ($(MACHINE),karolina)
    MPIF90 = mpif90
+   ifeq ($(COMPILER),GNU)
+      FFLAGS_OPT += -march=native
+      # link-time optimization accross files
+      LDFLAGS += -flto -fwhole-program
+      FFLAGS_OPT += -flto -fwhole-program
+   endif
 endif
 
 #
 ifeq ($(MACHINE),leonardo)
    MPIF90 = mpiifort
+   ifeq ($(COMPILER),INTEL)
+      # link-time optimization and inlining accross files
+      LDFLAGS += -ipo -inline-forceinline
+      FFLAGS_OPT += -ipo -inline-forceinline
+   endif
 endif
 
 #
@@ -29,11 +46,19 @@ ifeq ($(MACHINE),lumi)
    MPIF90 = ftn
    # mismatch flag needed to circumvent MPI_ALLREDUCE error
    FFLAGS_BASE += -fallow-argument-mismatch
+   # link-time optimization accross files
+   LDFLAGS += -flto -fwhole-program
+   FFLAGS_OPT += -flto -fwhole-program
 endif
 
 #
 ifeq ($(MACHINE),marenostrum)
    MPIF90 = mpif90
+   ifeq ($(COMPILER),INTEL)
+      # link-time optimization and inlining accross files
+      LDFLAGS += -ipo -inline-forceinline
+      FFLAGS_OPT += -ipo -inline-forceinline
+   endif
 endif
 
 #
@@ -41,10 +66,19 @@ ifeq ($(MACHINE),meluxina)
    MPIF90 = mpif90
    ifeq ($(COMPILER),GNU)
       FFLAGS_OPT += -march=native
+      # link-time optimization accross files
+      LDFLAGS += -flto -fwhole-program
+      FFLAGS_OPT += -flto -fwhole-program
    endif
 endif
 
 #
 ifeq ($(MACHINE),vega)
    MPIF90 = mpif90
+   ifeq ($(COMPILER),GNU)
+      FFLAGS_OPT += -march=native
+      # link-time optimization accross files
+      LDFLAGS += -flto -fwhole-program
+      FFLAGS_OPT += -flto -fwhole-program
+   endif
 endif


### PR DESCRIPTION
The flto optimization flags are moved to the presets of clusters.
This should fix the failed compilation on arm64 processors, which can be found in macbooks.
