### PR TITLE
move build variables to a module

### DIFF
--- a/amr/amr_commons.f90
+++ b/amr/amr_commons.f90
@@ -23,10 +23,6 @@ module amr_commons
   real(dp)::rho_tot=0.0D0                       ! Mean density in the box
   real(dp)::t=0.0D0                             ! Time variable
 
-  ! executable identification
-  CHARACTER(LEN=300)::builddate,buildcommand,patchdir
-  CHARACTER(LEN=300)::gitrepo,gitbranch,githash
-
   ! Save namelist filename
   CHARACTER(LEN=300)::namelist_file
 

--- a/amr/output_amr.f90
+++ b/amr/output_amr.f90
@@ -14,6 +14,7 @@ subroutine dump_all
   use turb_commons
 #endif
   use mpi_mod
+  use buildinfo
   implicit none
 #if ! defined (WITHOUTMPI) || defined (NOSYSTEM)
   integer::info
@@ -96,12 +97,7 @@ subroutine dump_all
      ! Copy compilation details to output directory
      filename=TRIM(filedir)//'compilation.txt'
      OPEN(UNIT=11, FILE=filename, FORM='formatted')
-     write(11,'(" compile date    = ",A)')TRIM(builddate)
-     write(11,'(" compile command = ",A)')TRIM(buildcommand)
-     write(11,'(" patch dir       = ",A)')TRIM(patchdir)
-     write(11,'(" remote repo     = ",A)')TRIM(gitrepo)
-     write(11,'(" local branch    = ",A)')TRIM(gitbranch)
-     write(11,'(" last commit     = ",A)')TRIM(githash)
+     call write_gitinfo(11)
      CLOSE(11)
   endif
 #ifndef WITHOUTMPI

--- a/amr/read_params.f90
+++ b/amr/read_params.f90
@@ -2,6 +2,8 @@ subroutine read_params
   use amr_commons
   use hydro_parameters, only:nvar,nhydro
   use mpi_mod
+  use buildinfo
+  use iso_fortran_env, ONLY: output_unit !standard output
   implicit none
   !--------------------------------------------------
   ! Local variables
@@ -81,7 +83,9 @@ subroutine read_params
   if(IOGROUPSIZE>0.or.IOGROUPSIZECONE>0.or.IOGROUPSIZEREP>0)write(*,*)' '
 
   ! Write information about git version
-  call write_gitinfo
+  write(*,*)' '
+  call write_gitinfo(output_unit)
+  write(*,*)' '
 
   ! Read namelist filename from command line argument
   narg = command_argument_count()

--- a/amr/write_gitinfo.f90
+++ b/amr/write_gitinfo.f90
@@ -1,20 +1,27 @@
-subroutine write_gitinfo
-  use amr_commons, ONLY:builddate,buildcommand,patchdir,gitrepo,gitbranch,githash
+module buildinfo
+  implicit none
 
-  builddate = BUILDDATE
-  buildcommand = BUILDCOMMAND
-  patchdir  = PATCH
-  gitrepo   = GITREPO
-  gitbranch = GITBRANCH
-  githash   = GITHASH
+  ! Variables for executable identification
+  ! Set at compile time (via -D flags)
+  character(len=300),parameter::builddate    = BUILDDATE
+  character(len=300),parameter::buildcommand = BUILDCOMMAND
+  character(len=300),parameter::patchdir     = PATCH
+  character(len=300),parameter::gitrepo      = GITREPO
+  character(len=300),parameter::gitbranch    = GITBRANCH
+  character(len=300),parameter::githash      = GITHASH
 
-  write(*,*)' '
-  write(*,'(" compile date    = ",A)')TRIM(builddate)
-  write(*,'(" compile command = ",A)')TRIM(buildcommand)
-  write(*,'(" patch dir       = ",A)')TRIM(patchdir)
-  write(*,'(" remote repo     = ",A)')TRIM(gitrepo)
-  write(*,'(" local branch    = ",A)')TRIM(gitbranch)
-  write(*,'(" last commit     = ",A)')TRIM(githash)
-  write(*,*)' '
+contains
 
-end subroutine write_gitinfo
+  subroutine write_gitinfo(unit)
+    integer,intent(in)::unit
+
+    write(unit,'(" compile date    = ",A)')TRIM(builddate)
+    write(unit,'(" compile command = ",A)')TRIM(buildcommand)
+    write(unit,'(" patch dir       = ",A)')TRIM(patchdir)
+    write(unit,'(" remote repo     = ",A)')TRIM(gitrepo)
+    write(unit,'(" local branch    = ",A)')TRIM(gitbranch)
+    write(unit,'(" last commit     = ",A)')TRIM(githash)
+
+  end subroutine write_gitinfo
+
+end module buildinfo


### PR DESCRIPTION
Upgrade write_gitinfo.f90 to a module. Move the definition of the executable variables from amr_commons to this new module. Reuse the code of the subroutine write_gitinfo to write the file compilation.txt in output_amr.f90.
