### PR TITLE
`use buildinfo` in `read_params` of the dice patch

### DIFF
--- a/patch/init/dice/read_params.f90
+++ b/patch/init/dice/read_params.f90
@@ -60,6 +60,9 @@ subroutine read_params
   use amr_commons
   use hydro_parameters, only:nvar,nhydro
   use mpi_mod
+  use buildinfo
+  use iso_fortran_env, ONLY: output_unit !standard output
+
   implicit none
   !--------------------------------------------------
   ! Local variables
@@ -139,7 +142,9 @@ subroutine read_params
   if(IOGROUPSIZE>0.or.IOGROUPSIZECONE>0.or.IOGROUPSIZEREP>0)write(*,*)' '
 
   ! Write information about git version
-  call write_gitinfo
+  write(*,*)' '
+  call write_gitinfo(output_unit)
+  write(*,*)' '
 
   ! Read namelist filename from command line argument
   narg = command_argument_count()


### PR DESCRIPTION
<!-- Thank you so much for your contribution! -->
<!-- First describe what your PR is doing.  -->
This PR fixes a bug where the dice patch compilation fails due to `write_gitinfo`. The compilation error reads "undefined reference to `write_gitinfo_`". Importing `buildinfo` and passing the argument fixed the issue. This might have to fixed for other `read_params` files as well. 

<!--
> [!WARNING]
>  Please uncomment this to tell everyone if there is a breacking change.
-->

<!-- Please check the following points -->
## PR Checklist

- [ ] The pull request has a title and a description
- [ ] For new code features, the PR should have been tested (please include the results of the tests below or, when possible, add a new test for the feature).
- [ ] The code covered by the pull request is documented
