### PR TITLE
[Test suite] Improvements to testing restarts

### DIFF
--- a/tests/run_with_restart.py
+++ b/tests/run_with_restart.py
@@ -79,9 +79,11 @@ def step_1(test_name):
     if "noutput" in nml["output_params"]:
         assert(nml["output_params"]["noutput"] == 1)
         nml = apply_output_factor(nml, 0.5)
+    elif "tout" in nml["output_params"]:
+        nout = len(nml["output_params"]["tout"])
+        nml["output_params"]["tout"] = nml["output_params"]["tout"][0:int(nout/2)]
     else:
         assert("tend" in nml["output_params"])
-        assert("tout" not in nml["output_params"])
         assert("foutput" in nml["output_params"])
         tend = nml["output_params"]["tend"]
         nml["output_params"]["tend"] = tend / 2
@@ -97,16 +99,21 @@ def step_2(test_name):
     nml_path = f"{test_name}.nml"
     nml = f90nml.read(nml_path)
 
+    # Find the last output time
+    all_outputs = sorted(glob.glob("output_*"))
+    last_output = int(all_outputs[-1].split("_")[-1])
+    print(f"Restarting from output {last_output}")
+    nml["run_params"]["nrestart"] = last_output
 
     if "noutput" in nml["output_params"]:
         nml["run_params"]["nrestart"] = 2
         nml["output_params"]["noutput"] = 2
         nml = apply_output_factor(nml, 2, add_extra_output_time=True)
+    elif "tout" in nml["output_params"]:
+        # recover original output list from namelist
+        nml_orig = f90nml.read(nml_path + "_backup")
+        nml["output_params"]["tout"] = nml_orig["output_params"]["tout"]
     else:
-        # Find the last output time
-        last_output = int(glob.glob("output_*")[-1].split("_")[-1])
-        print(f"Restarting from output {last_output}")
-        nml["run_params"]["nrestart"] = last_output
         tend = nml["output_params"]["tend"]
         nml["output_params"]["tend"] = tend * 2
 


### PR DESCRIPTION
Allow for tout to be used with the restart mechanism
Fix an issue where the number of the last output was not correctly identified in step 2, due to the result of glob being not in alphabetical order.