### PR TITLE
Start arrays flag1 and flag2 from 1 instead of 0

### DIFF
--- a/amr/flag_utils.f90
+++ b/amr/flag_utils.f90
@@ -31,7 +31,7 @@ subroutine flag_coarse
   ! Constants
   nxny=nx*ny
   ! Reset flag1 array at coarse level
-  flag1(0:ncoarse)=0
+  flag1(1:ncoarse)=0
   ! Set flag1 to 1 at coarse level for inner cells only
   nflag=0
   do iz=kcoarse_min,kcoarse_max
@@ -572,7 +572,6 @@ subroutine smooth_fine(ilevel)
   if(numbtot(1,ilevel)==0)return
 
   n_nbor(1:3)=(/1,2,2/)
-  flag1(0)=0
   ncache=active(ilevel)%ngrid
   ! Loop over steps
   do ismooth=1,ndim

--- a/amr/init_amr.f90
+++ b/amr/init_amr.f90
@@ -49,8 +49,8 @@ subroutine init_amr
   dtnew=0.0D0
 
   ! Allocate AMR cell-based arrays
-  allocate(flag1(0:ncell)) ! Note: starting from 0
-  allocate(flag2(0:ncell)) ! Note: starting from 0
+  allocate(flag1(1:ncell))
+  allocate(flag2(1:ncell))
   allocate(son  (1:ncell)) ! Son index
   flag1=0; flag2=0; son=0
 

--- a/utils/f90/dbl2sng.f90
+++ b/utils/f90/dbl2sng.f90
@@ -168,7 +168,7 @@ program dbl2sng
         mapping=0
         allocate(headl2(1:ncpu,1:nlevelmax))
         allocate(taill2(1:ncpu,1:nlevelmax))
-        allocate(flag1(0:ncell2))
+        allocate(flag1(1:ncell2))
         allocate(cpu_map(1:ncell2))
         allocate(xg(1:ngridmax2,1:ndim))
         allocate(father(1:ngridmax2))

--- a/utils/f90/defrag.f90
+++ b/utils/f90/defrag.f90
@@ -156,7 +156,7 @@ program defrag
         mapping=0
         allocate(headl2(1:ncpu,1:nlevelmax))
         allocate(taill2(1:ncpu,1:nlevelmax))
-        allocate(flag1(0:ncell2))
+        allocate(flag1(1:ncell2))
         allocate(cpu_map(1:ncell2))
         allocate(xg(1:ngridmax2,1:ndim))
         allocate(father(1:ngridmax2))


### PR DESCRIPTION
I couldn't find a reason why they should start from 0.