### PR TITLE
bugfix in quick_sort_int_int

### DIFF
--- a/amr/sort.f90
+++ b/amr/sort.f90
@@ -319,6 +319,13 @@ SUBROUTINE quick_sort_int_int(list, order, n)
   INTEGER, DIMENSION (1:n), INTENT(INOUT)  :: order
 
 
+  ! Local variable
+  INTEGER :: i
+
+  DO i = 1, n
+     order(i) = i
+  END DO
+
   CALL quick_sort_1_int_int(1, n)
 
 CONTAINS


### PR DESCRIPTION
Fix a bug where order is uninitialized in the integer version of quick_sort. This causes the returned order book-keeping array to be incorrect (possibly all 0).
This routine is used in the merger_tree module.