### PR TITLE
Documentation improvements (add missing links)

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,7 +1,7 @@
 # Welcome!
 
-Please visit (link to read the docs here) for the official user and devloper documentaion of `ramses`.
-If you are navigating using the GitHub webpage for a quick look at the markdown files, you can find a table of contenets below:
+Please visit [Read the Docs](https://ramses-organisation.readthedocs.io/en/latest/index.html) for the official user and devloper documentaion of `ramses`.
+If you are navigating using the GitHub webpage for a quick look at the markdown files, you can find a table of contents below:
 
 # [Chapter 1. Getting started](./wiki/Start.md)
 1. [Obtaining the package](./wiki/Start.md#obtaining-the-package)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -19,7 +19,7 @@ generated output files. A pdf version of this documentation can be found
 `here <Ramses.pdf>`_.
 
 **New users of Ramses are invited to follow the ramses's** `tutorials <https://ramses-tutorials.readthedocs.io/en/latest/>`_,
-**that covers the basics to setup a simulation and helps to get started
+**that cover the basics to setup a simulation and help with getting started
 with some common applications.**
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -5,7 +5,7 @@
 Ramses Documentation
 ######################
 
-The `ramses` code is intended to be a versatile platform to develop
+The `Ramses` code is intended to be a versatile platform to develop
 applications using  Adaptive Mesh  Refinement (AMR)  for computational
 astrophysics.  The current implementation allows solving the classical
 and relativistic Euler equations in presence of self-gravity, magnetic
@@ -17,6 +17,10 @@ suite  of post-processing  routines  is delivered  within the  present
 release,  allowing  the user  to  perform  a  simple analysis  of  the
 generated output files. A pdf version of this documentation can be found
 `here <Ramses.pdf>`_.
+
+**New users of Ramses are invited to follow the ramses's** `tutorials <https://ramses-tutorials.readthedocs.io/en/latest/>`_,
+**that covers the basics to setup a simulation and helps to get started
+with some common applications.**
 
 
 Table of Contents


### PR DESCRIPTION
Documentation improvements:

* Updated the main README to link to the official Read the Docs site and fixed typos in the table of contents section.
* Added a highlighted section in `doc/index.rst` inviting new users to follow the Ramses tutorials.

See https://github.com/ramses-organisation/ramses-tutorials/issues/1
