### PR TITLE
Update tests workflow to always run tests + other CI fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ defaults:
     shell: bash
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
   cancel-in-progress: true
 
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,11 @@ defaults:
   run:
     shell: bash
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
 jobs:
     build:
         name: "${{ matrix.test-type }} in ${{ matrix.ndim }}D"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,7 +3,6 @@ name: Test RAMSES
 
 on:
   pull_request:
-    types: [labeled]
   workflow_dispatch:
 
 defaults:
@@ -14,7 +13,6 @@ jobs:
 
     run:
         name: "Tests ${{ matrix.test-family }}"
-        if: ${{ github.event.label.name == 'run tests' }}
         runs-on: ubuntu-latest
         strategy:
             matrix:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,11 @@ defaults:
   run:
     shell: bash
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
 jobs:
 
     run:

--- a/tests/poisson/cosmo/before-test.sh
+++ b/tests/poisson/cosmo/before-test.sh
@@ -1,6 +1,6 @@
 if [ ! -d "cosmo_128" ]; then
     echo "cosmo_128 directory does not exist, dowloading it..."
-    wget --timeout=10 --tries=3 https://ramses.cnrs.fr/wp-content/uploads/2025/01/cosmo_128.zip
+    wget --timeout=10 --tries=3 --no-check-certificate https://ramses.cnrs.fr/wp-content/uploads/2025/01/cosmo_128.zip
     unzip cosmo_128.zip
     rm cosmo_128.zip
 

--- a/tests/star/SNFB/before-test.sh
+++ b/tests/star/SNFB/before-test.sh
@@ -1,6 +1,6 @@
 if [ ! -d "cosmo_128" ]; then
     echo "cosmo_128 directory does not exist, dowloading it..."
-    wget https://ramses.cnrs.fr/wp-content/uploads/2025/01/cosmo_128.zip
+    wget --timeout=10 --tries=3 --no-check-certificate https://ramses.cnrs.fr/wp-content/uploads/2025/01/cosmo_128.zip
     unzip cosmo_128.zip
     rm cosmo_128.zip
 


### PR DESCRIPTION
This PR:
 - removes he condition for running tests based on labels,
 - removes the certificate check when downloading the cosmo init file,
 - add the configuration to cancel a test/build when a new workflow is launched.

