### PR TITLE
Add the option to output the electric current

### DIFF
--- a/amr/amr_parameters.f90
+++ b/amr/amr_parameters.f90
@@ -125,6 +125,8 @@ module amr_parameters
   logical::output_to_log=.true.  ! write output to log for 1D runs
   logical::write_conservative=.false. ! output conservative variables instead of primitive ones
   logical::read_conservative=.false.  ! restart from an output which contains conservative variables
+  logical::output_current=.false.     ! output cell-centred electric current density (NIMHD only)
+  logical::input_current=.false.      ! restart file contains electric current
 
   ! Lightcone parameters
   real(dp)::thetay_cone=12.5d0

--- a/amr/amr_parameters.f90
+++ b/amr/amr_parameters.f90
@@ -125,7 +125,7 @@ module amr_parameters
   logical::output_to_log=.true.  ! write output to log for 1D runs
   logical::write_conservative=.false. ! output conservative variables instead of primitive ones
   logical::read_conservative=.false.  ! restart from an output which contains conservative variables
-  logical::output_current=.false.     ! output cell-centred electric current density (NIMHD only)
+  logical::output_current=.false.     ! output cell-centred electric current density (MHD only)
   logical::input_current=.false.      ! restart file contains electric current
 
   ! Lightcone parameters

--- a/amr/read_params.f90
+++ b/amr/read_params.f90
@@ -471,7 +471,8 @@ subroutine read_output_params(namelist_unit,nml_ok)
    ! Parameters to specify when to write an output
    namelist/output_params/noutput,foutput,aout,tout &
    & ,tend,delta_tout,aend,delta_aout,gadget_output,walltime_hrs,minutes_dump &
-   & ,output_to_log,write_conservative,read_conservative,exact_output_time
+   & ,output_to_log,write_conservative,read_conservative,exact_output_time &
+   & ,output_current,input_current
 
    ! Go to the beginning of the file
    rewind(namelist_unit)

--- a/doc/wiki/Output.md
+++ b/doc/wiki/Output.md
@@ -10,6 +10,7 @@ This namelist block, called `&OUTPUT_PARAMS`, is used to set up the frequency an
 | `foutput=1000000` | `integer` | Frequency of additional outputs in units of coarse time steps. `foutput=1` means one output at each time step. Specified outputs (see above) will not be superseded by this parameter. |
 | `tout=0.0,0.0,0.0,` | `real array` | Value of specified output times. |
 | `aout=1.1,1.1,1.1,` | `real array` | Value of specified output expansion factor (for cosmology runs only). `aout=1.0` means "present epoch" or "zero redshift". |
+| `exact_output_time=.false.` | `logical` | Enforce outputs at the exact requested times (`tout` or `aout`) by adjusting the timestep. |
 | `delta_tout=0` | `real` | Frequency of outputs in user time units. |
 | `delta_aout=0` | `real` | Frequency of outputs in expansion factor (for cosmology runs only). |
 | `tend=10` | `real` | End time of the simulation, in user time units. |
@@ -18,7 +19,8 @@ This namelist block, called `&OUTPUT_PARAMS`, is used to set up the frequency an
 | `minutes_dump=1` | `real` | Dump an output this many minutes before walltime_hrs |
 | `write_conservative=.false.` | `logical` | Output conservative hydro variables as stored in `uold` instead of primitive ones |
 | `read_conservative=.false.` | `logical` | When conservative variables have been outputted, this flag should be set to `.true.` to match the correct variables on restart. |
-| `exact_output_time=.false.` | `logical` | Enforce outputs at the exact requested times (`tout` or `aout`) by adjusting the timestep. |
+| `output_current=.false.` | `logical` | Output cell-centred electric current density (MHD only) |
+| `input_current=.false.` | `logical` | Restart file contains electric current |
 
 > **Warning (R. Teyssier)**
 > When using the `exact_output_time` option, having an abrupt change of time step can potentially affect the quality of the solution.

--- a/hydro/hydro_commons.f90
+++ b/hydro/hydro_commons.f90
@@ -6,6 +6,7 @@ module hydro_commons
   real(dp),allocatable,dimension(:)::pstarold,pstarnew ! Stellar momentum and its update
   real(dp),allocatable,dimension(:)::divu,enew ! Non conservative variables
   real(dp),allocatable,dimension(:)::rho_eq,p_eq ! Strict hydrostatic equilibrium
+  real(dp),allocatable,dimension(:,:)::electric_current ! Cell-centred current density J=curl(B), 3 components
   real(dp)::mass_tot=0,mass_tot_0=0
   real(dp)::ana_xmi,ana_xma,ana_ymi,ana_yma,ana_zmi,ana_zma
   integer::nbins

--- a/hydro/init_hydro.f90
+++ b/hydro/init_hydro.f90
@@ -31,6 +31,12 @@ subroutine init_hydro
   allocate(uold(1:ncell,1:nvar_all))
   allocate(unew(1:ncell,1:nvar_all))
   uold=0.0d0; unew=0.0d0
+#ifdef SOLVERmhd
+  if(output_current) then
+     allocate(electric_current(1:ncell,1:3))
+     electric_current=0.0d0
+  end if
+#endif
   if(MC_tracer) then
      allocate(fluxes(1:ncell,1:twondim))
      fluxes(1:ncell,1:twondim)=0.0d0
@@ -84,6 +90,9 @@ subroutine init_hydro
      if(strict_equilibrium>0)nvar2=nvar2-2
 #ifdef SOLVERmhd
      nvar2=nvar2-3
+     if(input_current)then
+        nvar2=nvar2-3
+     end if
 #endif
      read(ilun)ndim2
      read(ilun)nlevelmax2
@@ -231,6 +240,14 @@ subroutine init_hydro
                     end do
                  endif
 
+                 ! Skip the electric current
+#ifdef SOLVERmhd
+                 if(input_current) then
+                    read(ilun)xx  ! discard J_x
+                    read(ilun)xx  ! discard J_y
+                    read(ilun)xx  ! discard J_z
+                 end if
+#endif
               end do
               deallocate(ind_grid,xx)
            end if

--- a/hydro/output_hydro.f90
+++ b/hydro/output_hydro.f90
@@ -18,7 +18,7 @@ subroutine backup_hydro(filename, filename_desc)
   character(LEN = 80) :: fileloc
   integer, parameter :: tag = 1121
   logical :: dump_info_flag
-  integer :: info_var_count
+  integer :: info_var_count, nvar_output
   character(len=100) :: field_name
 
   if (verbose) write(*,*)'Entering backup_hydro'
@@ -47,12 +47,18 @@ subroutine backup_hydro(filename, filename_desc)
      dump_info_flag = .false.
   end if
 
-  write(unit_out) ncpu
+  nvar_output = nvar_all
   if(strict_equilibrium>0)then
-     write(unit_out) nvar_all+2
-  else
-     write(unit_out) nvar_all
+     nvar_output=nvar_output+2
   endif
+#ifdef SOLVERmhd
+  if(output_current)then
+     nvar_output=nvar_output+3
+  end if
+#endif
+
+  write(unit_out) ncpu
+  write(unit_out) nvar_output
   write(unit_out) ndim
   write(unit_out) nlevelmax
   write(unit_out) nboundary
@@ -167,6 +173,18 @@ subroutine backup_hydro(filename, filename_desc)
                  field_name = 'equilibrium_pressure'
                  call generic_dump(field_name, info_var_count, xdp, unit_out, dump_info_flag, unit_info)
               endif
+#ifdef SOLVERmhd
+              ! Write electric current if requested, at the very end (we do not want to read it on restart)
+              if(output_current) then
+                 do ivar = 1, 3
+                    field_name = 'current_' // dim_keys(ivar)
+                    do i = 1, ncache
+                       xdp(i) = electric_current(ind_grid(i)+iskip, ivar)
+                    end do
+                    call generic_dump(field_name, info_var_count, xdp, unit_out, dump_info_flag, unit_info)
+                 end do
+              end if
+#endif
               ! We did one output, deactivate dumping of variables
               dump_info_flag = .false.
            end do

--- a/mhd/godunov_fine.f90
+++ b/mhd/godunov_fine.f90
@@ -955,8 +955,6 @@ subroutine godfine1(ind_grid,ncache,ilevel)
   !-------------------------------------------------------
 #ifdef SOLVERmhd
   if(output_current) then
-     ! J = curl(B) at cell centres, using face-centred B from uloc
-     ! uloc(:,:,:,:,6)=Bx at left x-face, 7=By at left y-face, 8=Bz at left z-face
      do k2=k2min,k2max
      do j2=j2min,j2max
      do i2=i2min,i2max
@@ -969,12 +967,23 @@ subroutine godfine1(ind_grid,ncache,ilevel)
         j3=1+j2
         k3=1+k2
         do i=1,ncache
-           electric_current(ind_cell(i),1) = (uloc(i,i3,j3+1,k3,8) - uloc(i,i3,j3,k3,8))/dx &
-                                           - (uloc(i,i3,j3,k3+1,7) - uloc(i,i3,j3,k3,7))/dx
-           electric_current(ind_cell(i),2) = (uloc(i,i3,j3,k3+1,6) - uloc(i,i3,j3,k3,6))/dx &
-                                           - (uloc(i,i3+1,j3,k3,8) - uloc(i,i3,j3,k3,8))/dx
-           electric_current(ind_cell(i),3) = (uloc(i,i3+1,j3,k3,7) - uloc(i,i3,j3,k3,7))/dx &
-                                           - (uloc(i,i3,j3+1,k3,6) - uloc(i,i3,j3,k3,6))/dx
+           ! J = curl(B): central difference of cell-centred B (avg of left+right face)
+           ! over two cells (2*dx), so the result is centred on the active cell
+           electric_current(ind_cell(i),1) = &
+              (0.5d0*(uloc(i,i3,j3+1,k3,8)+uloc(i,i3,j3+1,k3,nvar+3)) - &
+               0.5d0*(uloc(i,i3,j3-1,k3,8)+uloc(i,i3,j3-1,k3,nvar+3))) / (2.0d0*dx) &
+            - (0.5d0*(uloc(i,i3,j3,k3+1,7)+uloc(i,i3,j3,k3+1,nvar+2)) - &
+               0.5d0*(uloc(i,i3,j3,k3-1,7)+uloc(i,i3,j3,k3-1,nvar+2))) / (2.0d0*dx)
+           electric_current(ind_cell(i),2) = &
+              (0.5d0*(uloc(i,i3,j3,k3+1,6)+uloc(i,i3,j3,k3+1,nvar+1)) - &
+               0.5d0*(uloc(i,i3,j3,k3-1,6)+uloc(i,i3,j3,k3-1,nvar+1))) / (2.0d0*dx) &
+            - (0.5d0*(uloc(i,i3+1,j3,k3,8)+uloc(i,i3+1,j3,k3,nvar+3)) - &
+               0.5d0*(uloc(i,i3-1,j3,k3,8)+uloc(i,i3-1,j3,k3,nvar+3))) / (2.0d0*dx)
+           electric_current(ind_cell(i),3) = &
+              (0.5d0*(uloc(i,i3+1,j3,k3,7)+uloc(i,i3+1,j3,k3,nvar+2)) - &
+               0.5d0*(uloc(i,i3-1,j3,k3,7)+uloc(i,i3-1,j3,k3,nvar+2))) / (2.0d0*dx) &
+            - (0.5d0*(uloc(i,i3,j3+1,k3,6)+uloc(i,i3,j3+1,k3,nvar+1)) - &
+               0.5d0*(uloc(i,i3,j3-1,k3,6)+uloc(i,i3,j3-1,k3,nvar+1))) / (2.0d0*dx)
         end do
      end do
      end do

--- a/mhd/godunov_fine.f90
+++ b/mhd/godunov_fine.f90
@@ -950,6 +950,38 @@ subroutine godfine1(ind_grid,ncache,ilevel)
      end do
   end do
 
+  !-------------------------------------------------------
+  ! Compute and store the electric current at level ilevel
+  !-------------------------------------------------------
+#ifdef SOLVERmhd
+  if(output_current) then
+     ! J = curl(B) at cell centres, using face-centred B from uloc
+     ! uloc(:,:,:,:,6)=Bx at left x-face, 7=By at left y-face, 8=Bz at left z-face
+     do k2=k2min,k2max
+     do j2=j2min,j2max
+     do i2=i2min,i2max
+        ind_son=1+i2+2*j2+4*k2
+        iskip=ncoarse+(ind_son-1)*ngridmax
+        do i=1,ncache
+           ind_cell(i)=iskip+ind_grid(i)
+        end do
+        i3=1+i2
+        j3=1+j2
+        k3=1+k2
+        do i=1,ncache
+           electric_current(ind_cell(i),1) = (uloc(i,i3,j3+1,k3,8) - uloc(i,i3,j3,k3,8))/dx &
+                                           - (uloc(i,i3,j3,k3+1,7) - uloc(i,i3,j3,k3,7))/dx
+           electric_current(ind_cell(i),2) = (uloc(i,i3,j3,k3+1,6) - uloc(i,i3,j3,k3,6))/dx &
+                                           - (uloc(i,i3+1,j3,k3,8) - uloc(i,i3,j3,k3,8))/dx
+           electric_current(ind_cell(i),3) = (uloc(i,i3+1,j3,k3,7) - uloc(i,i3,j3,k3,7))/dx &
+                                           - (uloc(i,i3,j3+1,k3,6) - uloc(i,i3,j3,k3,6))/dx
+        end do
+     end do
+     end do
+     end do
+  end if
+#endif
+
   !---------------------------------------------------------
   ! Conservative update at level ilevel for induction system
   !---------------------------------------------------------


### PR DESCRIPTION
Reading and writing is managed by the new namelist parameters output_current and input_current.
The current is calculated in godfine1 from the magnetic field, and stored in the global cell-based array "electric_current".
When outputted, it is added as the last 3 variable.