### PR TITLE
[OpenMP] a few small fixes

### DIFF
--- a/amr/end.f90
+++ b/amr/end.f90
@@ -123,7 +123,7 @@ subroutine deallocate_pm
      if(allocated(vp)) deallocate(vp)
      if(allocated(xp)) deallocate(xp)
 
-#ifdef OPENMP
+#ifdef _OPENMP
      if(allocated(numbp_old)) deallocate(numbp_old)
      if(allocated(headp_old)) deallocate(headp_old)
      if(allocated(nextp_old)) deallocate(nextp_old)

--- a/amr/init_amr.f90
+++ b/amr/init_amr.f90
@@ -238,7 +238,7 @@ subroutine init_amr
      allocate(tailp(1:ngridmax))
      allocate(numbp(1:ngridmax))
      headp=0; tailp=0; numbp=0
-#ifdef OPENMP
+#ifdef _OPENMP
      allocate(numbp_old(1:ngridmax))
      allocate(headp_old(1:ngridmax))
      allocate(nextp_old(1:npartmax))

--- a/amr/load_balance.f90
+++ b/amr/load_balance.f90
@@ -1900,6 +1900,7 @@ subroutine defrag
   numbf=ngridmax-ngrid2
   prev(headf)=0
   next(tailf)=0
+  ngrid_current=ngrid2
 !$omp end single nowait
 !$omp do
   do i=ngrid2+2,ngridmax
@@ -1914,8 +1915,6 @@ subroutine defrag
   do i=1,nlevelmax
      call build_comm(i)
   end do
-
-  ngrid_current=ngrid2
 
 end subroutine defrag
 !#########################################################################

--- a/amr/ramses.f90
+++ b/amr/ramses.f90
@@ -21,7 +21,7 @@ end program ramses
 subroutine initialize_mpi
   use amr_commons, only:myid,ncpu,nthr
   use mpi_mod
-#ifdef OPENMP
+#ifdef _OPENMP
   use omp_lib
 #endif
   implicit none
@@ -35,7 +35,7 @@ integer::mythr
   ncpu=1
   myid=1
 #else
-#ifdef OPENMP
+#ifdef _OPENMP
   call MPI_INIT_THREAD(MPI_THREAD_SERIALIZED,info,ierr)
   if(info<MPI_THREAD_SERIALIZED) then
       write(*,*) 'Error: MPI_THREAD_SERIALIZED is not supported in current MPI library'
@@ -49,7 +49,7 @@ integer::mythr
   myid=myid+1 ! Careful with this...
 #endif
 
-#ifdef OPENMP
+#ifdef _OPENMP
 !$omp parallel private(mythr)
   mythr=omp_get_thread_num()+1
   if(mythr==1) then

--- a/amr/read_params.f90
+++ b/amr/read_params.f90
@@ -49,7 +49,7 @@ subroutine read_params
   write(*,*)'       written by Romain Teyssier (Princeton University)       '
   write(*,*)'           (c) CEA 1999-2007, UZH 2008-2021, PU 2022           '
   write(*,*)' '
-#ifdef OPENMP
+#ifdef _OPENMP
   write(*,'(" Working with nproc = ",I4," and nthr = ",I3," for ndim = ",I1)')ncpu,nthr,ndim
 #else
   write(*,'(" Working with nproc = ",I5," for ndim = ",I1)')ncpu,ndim

--- a/hydro/uplmde.f90
+++ b/hydro/uplmde.f90
@@ -50,7 +50,7 @@ subroutine tracex(q,qm,qp,dx,dt,ngrid)
   real(dp),dimension(1:nvector,1:nvar,1:ndim)::dq
   real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar,1:ndim)::qm
   real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar,1:ndim)::qp
-  real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),save::c
+  real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2)::c
 
   ! Local variables
   integer ::ilo,ihi,jlo,jhi,klo,khi

--- a/mhd/uplmde.f90
+++ b/mhd/uplmde.f90
@@ -136,7 +136,7 @@ subroutine diffine1(ind_grid,ncache,dtdiff,ilevel)
   integer::ivar1,ivar2,ivar3,ivar4,ivar5,ivar6
   real(dp)::dx,dflux,weight,dflux_x,dflux_y,dflux_z,scale,dx_loc
 
-!$omp threadprivate(nbors_father_cells,ibuffer_father,B1,ind1,B2,ok,Bx,By,Bz,emfx,emfy,emfz,igrid_nbor,ind_cell,ind_buffer,exist_nbor)
+!$omp threadprivate(nbors_father_cells,ibuffer_father,B1,ind1,B2,ok,Bx,By,Bz,emfx,emfy,emfz,igrid_nbor,ind_cell,ind_buffer,igrid,exist_nbor)
 
   ! Mesh size at level ilevel in coarse cell units
   dx=0.5D0**ilevel

--- a/pm/particle_tree.f90
+++ b/pm/particle_tree.f90
@@ -230,7 +230,7 @@ subroutine make_tree_fine(ilevel)
   scale=boxlen/dble(nx_loc)
 
   ! Store old linked lists for indexing in parallel
-#ifdef OPENMP
+#ifdef _OPENMP
 !$omp parallel private(igrid,npart1,ipart,next_part)
   do icpu=1,ncpu
 !$omp do schedule(dynamic,10)
@@ -272,7 +272,7 @@ subroutine make_tree_fine(ilevel)
         else
            igrid=reception(icpu,ilevel)%igrid(jgrid)
         end if
-#ifdef OPENMP
+#ifdef _OPENMP
         npart1=numbp_old(igrid)  ! Number of particles in the grid
 #else
         npart1=numbp(igrid)  ! Number of particles in the grid
@@ -280,7 +280,7 @@ subroutine make_tree_fine(ilevel)
         if(npart1>0)then
            ig=ig+1
            ind_grid(ig)=igrid
-#ifdef OPENMP
+#ifdef _OPENMP
            ipart=headp_old(igrid)
 #else
            ipart=headp(igrid)
@@ -288,7 +288,7 @@ subroutine make_tree_fine(ilevel)
            ! Loop over particles
            do jpart=1,npart1
               ! Save next particle  <--- Very important !!!
-#ifdef OPENMP
+#ifdef _OPENMP
               next_part=nextp_old(ipart)
 #else
               next_part=nextp(ipart)

--- a/pm/synchro_fine.f90
+++ b/pm/synchro_fine.f90
@@ -512,6 +512,7 @@ subroutine sync(ind_grid,ind_part,ind_grid_part,ng,np,ilevel)
            if ( is_cloud(typep(ind_part(j))) ) then
               isink=-idp(ind_part(j))
               if(.not. direct_force_sink(isink))then
+!$omp atomic update
                  fsink_new(isink,idim)=fsink_new(isink,idim)+ff(j,idim)
               endif
            endif

--- a/poisson/multigrid_fine_coarse.f90
+++ b/poisson/multigrid_fine_coarse.f90
@@ -47,7 +47,7 @@ subroutine restrict_mask_coarse_reverse(ifinelevel)
       iskip_f_mg =(ind_f_cell-1)*active_mg(myid,ifinelevel)%ngrid
 
       ! Loop over fine grids of myid
-!$omp do
+!$omp do schedule(static)
       do igrid_f_mg=1,active_mg(myid,ifinelevel)%ngrid
          icell_f_mg=iskip_f_mg+igrid_f_mg
 #ifdef LIGHT_MPI_COMM
@@ -464,7 +464,7 @@ subroutine restrict_residual_coarse_reverse(ifinelevel)
       iskip_f_mg =(ind_f_cell-1)*active_mg(myid,ifinelevel)%ngrid
 
       ! Loop over fine grids of myid
-!$omp do
+!$omp do schedule(static)
       do igrid_f_mg=1,active_mg(myid,ifinelevel)%ngrid
          icell_f_mg=iskip_f_mg+igrid_f_mg
          ! Is fine cell masked?

--- a/poisson/multigrid_fine_fine.f90
+++ b/poisson/multigrid_fine_fine.f90
@@ -47,7 +47,7 @@ subroutine restrict_mask_fine_reverse(ifinelevel)
       iskip_f_amr=ncoarse+(ind_f_cell-1)*ngridmax
 
       ! Loop over fine grids of myid
-!$omp do
+!$omp do schedule(static)
       do igrid_f_mg=1,active(ifinelevel)%ngrid
          igrid_f_amr=active(ifinelevel)%igrid(igrid_f_mg)
          icell_f_amr=igrid_f_amr+iskip_f_amr
@@ -380,7 +380,7 @@ subroutine restrict_residual_fine_reverse(ifinelevel)
       iskip_f_amr=ncoarse+(ind_f_cell-1)*ngridmax
 
       ! Loop over fine grids of myid
-!$omp do
+!$omp do schedule(static)
       do igrid_f_mg=1,active(ifinelevel)%ngrid
          igrid_f_amr=active(ifinelevel)%igrid(igrid_f_mg)
          icell_f_amr=igrid_f_amr+iskip_f_amr


### PR DESCRIPTION
These are a few small fixes done in the hope of fixing a crash on the MareNostrum cluster.
* explicit static schedule in some places
* use of more robust _OPENMP macro
* fix for restarts in load_balance
* missing atomic for sink
* missing threadprivate in induction solver