### PR TITLE
remove dummy dt_new argument

### DIFF
--- a/rt/rt_spectra.f90
+++ b/rt/rt_spectra.f90
@@ -674,7 +674,7 @@ SUBROUTINE star_RT_feedback(ilevel, dt)
   ! End loop over cpus
 
   if(heat_unresolved_HII.gt.0) &
-       call heat_unresolved_HII_regions(ilevel,dtnew(ilevel))
+       call heat_unresolved_HII_regions(ilevel)
 
 111 format('   Entering star_rt_feedback for level ',I2)
 #endif


### PR DESCRIPTION
This micro PR fixes this warning: 

```
../rt/rt_spectra.f90:677:61: warning: type of ‘heat_unresolved_hii_regions’ does not match original declaration [-Wlto-type-mismatch]
  677 |        call heat_unresolved_HII_regions(ilevel,dtnew(ilevel))
      |                                                             ^
../rt/rt_cooling_module.f90:1260:38: note: type mismatch in parameter 2
 1260 | SUBROUTINE heat_unresolved_HII_regions(ilevel)
      |                                      ^
../rt/rt_cooling_module.f90:1260:38: note: ‘heat_unresolved_hii_regions’ was previously declared here
```

