### PR TITLE
Fix output params

### DIFF
--- a/amr/read_params.f90
+++ b/amr/read_params.f90
@@ -543,6 +543,9 @@ subroutine read_output_params(namelist_unit,nml_ok)
       aout(noutput)=aend
    endif
 
+   ! if no output time was requested at all, keep a single HUGE entry in the list
+   if(noutput==0)noutput=1
+
    ! set periodic output params
    tout_next=delta_tout
    aout_next=delta_aout

--- a/amr/read_params.f90
+++ b/amr/read_params.f90
@@ -471,7 +471,8 @@ subroutine read_output_params(namelist_unit,nml_ok)
 
    ! Parameters to specify when to write an output
    namelist/output_params/noutput,foutput,aout,tout &
-   & ,tend,delta_tout,aend,delta_aout,gadget_output,walltime_hrs,minutes_dump,output_to_log
+   & ,tend,delta_tout,aend,delta_aout,gadget_output,walltime_hrs,minutes_dump &
+   & ,output_to_log,write_conservative,read_conservative,exact_output_time
 
    ! Go to the beginning of the file
    rewind(namelist_unit)


### PR DESCRIPTION
Fix a few things that were broken in PR #288 

Now that `noutput` is complemently ignored in the namelist, the parameter `nstepmax` no longer worked as intended. When no output time was given, tout(0) went out of bound, causing the simulation to stop after 1 timestep. Setting noutput to a minimum of 1 keeps the target output time to HUGE, as before, so that the stopping criterion becomes nstepmax.

Restore` write_conservative,read_conservative,exact_output_time` parameters to the namelist. They were accidentally deleted, making these features inaccessible.
