### PR TITLE
Fix broken compilation of LIGHT MPI since dice patch merge

### DIFF
--- a/hydro/init_dice.f90
+++ b/hydro/init_dice.f90
@@ -32,7 +32,11 @@ subroutine dice_reset_uold(ilevel)
      iskip=ncoarse+(ind-1)*ngridmax
      do ivar=1,nvar_all
         do i=1,reception(icpu,ilevel)%ngrid
+#ifdef LIGHT_MPI_COMM
+           uold(reception(icpu,ilevel)%pcomm%igrid(i)+iskip,ivar)=0D0
+#else
            uold(reception(icpu,ilevel)%igrid(i)+iskip,ivar)=0D0
+#endif
         end do
      end do
   end do
@@ -120,7 +124,11 @@ subroutine dice_init_uold(ilevel)
      iskip=ncoarse+(ind-1)*ngridmax
      do ivar=1,nvar_all
         do i=1,reception(icpu,ilevel)%ngrid
+#ifdef LIGHT_MPI_COMM
+           uold(reception(icpu,ilevel)%pcomm%igrid(i)+iskip,ivar)=0.0
+#else
            uold(reception(icpu,ilevel)%igrid(i)+iskip,ivar)=0.0
+#endif
         end do
      end do
   end do
@@ -931,7 +939,11 @@ subroutine multipole_from_current_level(ilevel)
         iskip=ncoarse+(ind-1)*ngridmax
         do idim=1,ndim+1
            do j=1,reception(icpu,ilevel)%ngrid
+#ifdef LIGHT_MPI_COMM
+              unew(reception(icpu,ilevel)%pcomm%igrid(j)+iskip,idim)=0.0D0
+#else
               unew(reception(icpu,ilevel)%igrid(j)+iskip,idim)=0.0D0
+#endif
            end do
         end do
      end do

--- a/pm/particle_tree.f90
+++ b/pm/particle_tree.f90
@@ -1351,12 +1351,20 @@ subroutine fill_comm(ind_part,ind_com,ind_list,np,ilevel,icpu)
   ! DICE init for gas temperature
   if(dice_init) then
      do i=1,np
+#ifdef LIGHT_MPI_COMM
+        reception(icpu,ilevel)%pcomm%u(current_property,ind_com(i))=up(ind_part(i))
+#else
         reception(icpu,ilevel)%up(ind_com(i),current_property)=up(ind_part(i))
+#endif
      end do
      current_property = current_property+1
      if(cosmo) then
        do i=1,np
+#ifdef LIGHT_MPI_COMM
+          reception(icpu,ilevel)%pcomm%u(current_property,ind_com(i))=maskp(ind_part(i))
+#else
           reception(icpu,ilevel)%up(ind_com(i),current_property)=maskp(ind_part(i))
+#endif
        end do
        current_property = current_property+1
      endif
@@ -1560,12 +1568,20 @@ subroutine empty_comm(ind_com,np,ilevel,icpu)
   ! DICE init for gas temperature
   if(dice_init) then
      do i=1,np
+#ifdef LIGHT_MPI_COMM
+       up(ind_part(i))=emission_part(ilevel)%u(current_property, offset_np+ind_com(i)-1)
+#else
        up(ind_part(i))=emission(icpu,ilevel)%up(ind_com(i),current_property)
+#endif
      end do
      current_property = current_property+1
      if(cosmo) then
        do i=1,np
+#ifdef LIGHT_MPI_COMM
+         maskp(ind_part(i))=emission_part(ilevel)%u(current_property, offset_np+ind_com(i)-1)
+#else
          maskp(ind_part(i))=emission(icpu,ilevel)%up(ind_com(i),current_property)
+#endif
        end do
        current_property = current_property+1
      endif


### PR DESCRIPTION
Add the `LIGHT_MPI_COMM` preprocessor switch pattern for `reception` and `emission` arrays to dice related blocks. This restores compilation for LIGHT MPI.