### PR TITLE
[WIP] Fix grafic initial conditions with LIGHT_MPI_COMM

### DIFF
--- a/patch/hydro/merger/init_part.f90
+++ b/patch/hydro/merger/init_part.f90
@@ -736,7 +736,6 @@ contains
        deallocate(emission_part(1)%cpuid)
        deallocate(emission_part(1)%nparts)
        deallocate(emission_part(1)%u)
-       deallocate(emission_part(1)%f)
        deallocate(emission_part(1)%f8)
     end if
 
@@ -758,8 +757,8 @@ contains
     if(emission_part(1)%nactive>0)then
        allocate(emission_part(1)%cpuid(emission_part(1)%nactive))
        allocate(emission_part(1)%nparts(emission_part(1)%nactive))
-       allocate(emission_part(1)%u(emission_part(1)%nparts_tot*(twondim+1), 1:1))
-       allocate(emission_part(1)%f8(emission_part(1)%nparts_tot*2, 1:1))
+       allocate(emission_part(1)%u(1:twondim+1, 1:emission_part(1)%nparts_tot))
+       allocate(emission_part(1)%f8(1:2, 1:emission_part(1)%nparts_tot))
        idx=1
        do icpu=1,ncpu
          ncache=sendbuf(icpu)
@@ -779,16 +778,18 @@ contains
           call cmp_cpumap(xx_dp,cc,1)
           if(cc(1).ne.myid)then
              icpu=cc(1)
-             ibuf=sendbuf(icpu)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1),1)     = xp(ipart,1)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1) + 1,1) = xp(ipart,2)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1) + 2,1) = xp(ipart,3)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1) + 3,1) = vp(ipart,1)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1) + 4,1) = vp(ipart,2)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1) + 5,1) = vp(ipart,3)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1) + 6,1) = mp(ipart)
-             emission_part(1)%f8((sendbuf_cum(icpu)+ibuf)*2,1)              = part2int(typep(ipart))
-             emission_part(1)%f8((sendbuf_cum(icpu)+ibuf)*2 + 1,1)          = idp(ipart)
+             sendbuf(icpu)=sendbuf(icpu)+1
+             ! Index of the current particle inside the shared emission buffers
+             ibuf=sendbuf_cum(icpu)+sendbuf(icpu)
+             emission_part(1)%u(1,ibuf)=xp(ipart,1)
+             emission_part(1)%u(2,ibuf)=xp(ipart,2)
+             emission_part(1)%u(3,ibuf)=xp(ipart,3)
+             emission_part(1)%u(4,ibuf)=vp(ipart,1)
+             emission_part(1)%u(5,ibuf)=vp(ipart,2)
+             emission_part(1)%u(6,ibuf)=vp(ipart,3)
+             emission_part(1)%u(7,ibuf)=mp(ipart)
+             emission_part(1)%f8(1,ibuf)=part2int(typep(ipart))
+             emission_part(1)%f8(2,ibuf)=idp(ipart)
           else
              jpart=jpart+1
              xp(jpart,1:3)=xp(ipart,1:3)
@@ -860,8 +861,11 @@ contains
        ncache=recvbuf(icpu)
        if(ncache>0)then
 #ifdef LIGHT_MPI_COMM
-         allocate(reception(icpu,1)%pcomm%u(1:ncache,1:twondim+1))
-         allocate(reception(icpu,1)%pcomm%f8(1:ncache,1:2))
+         if(.not. associated(reception(icpu,1)%pcomm))then
+            allocate(reception(icpu,1)%pcomm)
+         end if
+         allocate(reception(icpu,1)%pcomm%u(1:twondim+1,1:ncache))
+         allocate(reception(icpu,1)%pcomm%f8(1:2,1:ncache))
 #else
          allocate(reception(icpu,1)%up(1:ncache,1:twondim+1))
          allocate(reception(icpu,1)%fp(1:ncache,1:2))
@@ -897,7 +901,7 @@ contains
           buf_count=ncache*(twondim+1)
           countsend=countsend+1
 #ifdef LIGHT_MPI_COMM
-          call MPI_ISEND(emission_part(1)%u(sendbuf_cum(icpu)+ncache,1),buf_count, &
+          call MPI_ISEND(emission_part(1)%u(1,sendbuf_cum(icpu)+1),buf_count, &
                & MPI_DOUBLE_PRECISION,icpu-1,&
                & tagu,MPI_COMM_WORLD,reqsend(countsend),info)
 #else
@@ -955,11 +959,11 @@ contains
           countsend=countsend+1
 #ifdef LIGHT_MPI_COMM
 #ifndef LONGINT
-          call MPI_ISEND(emission_part(1)%f8(sendbuf_cum(icpu)+ncache,1),buf_count, &
+          call MPI_ISEND(emission_part(1)%f8(1,sendbuf_cum(icpu)+1),buf_count, &
                 & MPI_INTEGER,icpu-1,&
                 & tagu,MPI_COMM_WORLD,reqsend(countsend),info)
 #else
-          call MPI_ISEND(emission_part(1)%f8(sendbuf_cum(icpu)+ncache,1),buf_count, &
+          call MPI_ISEND(emission_part(1)%f8(1,sendbuf_cum(icpu)+1),buf_count, &
                 & MPI_INTEGER8,icpu-1,&
                 & tagu,MPI_COMM_WORLD,reqsend(countsend),info)
 #endif
@@ -989,14 +993,14 @@ contains
        do ibuf=1,recvbuf(icpu)
           jpart=jpart+1
 #ifdef LIGHT_MPI_COMM
-          xp(jpart,1)=reception(icpu,1)%pcomm%u(ibuf,1)
-          xp(jpart,2)=reception(icpu,1)%pcomm%u(ibuf,2)
-          xp(jpart,3)=reception(icpu,1)%pcomm%u(ibuf,3)
-          vp(jpart,1)=reception(icpu,1)%pcomm%u(ibuf,4)
-          vp(jpart,2)=reception(icpu,1)%pcomm%u(ibuf,5)
-          vp(jpart,3)=reception(icpu,1)%pcomm%u(ibuf,6)
-          mp(jpart)  =reception(icpu,1)%pcomm%u(ibuf,7)
-          idp(jpart) =reception(icpu,1)%pcomm%f8(ibuf,2)
+          xp(jpart,1)=reception(icpu,1)%pcomm%u(1,ibuf)
+          xp(jpart,2)=reception(icpu,1)%pcomm%u(2,ibuf)
+          xp(jpart,3)=reception(icpu,1)%pcomm%u(3,ibuf)
+          vp(jpart,1)=reception(icpu,1)%pcomm%u(4,ibuf)
+          vp(jpart,2)=reception(icpu,1)%pcomm%u(5,ibuf)
+          vp(jpart,3)=reception(icpu,1)%pcomm%u(6,ibuf)
+          mp(jpart)  =reception(icpu,1)%pcomm%u(7,ibuf)
+          idp(jpart) =reception(icpu,1)%pcomm%f8(2,ibuf)
 #else
           xp(jpart,1)=reception(icpu,1)%up(ibuf,1)
           xp(jpart,2)=reception(icpu,1)%up(ibuf,2)
@@ -1026,8 +1030,14 @@ contains
 
     ! Deallocate communicators
 #ifdef LIGHT_MPI_COMM
-    deallocate(emission_part(1)%u)
-    deallocate(emission_part(1)%f8)
+    if(emission_part(1)%nactive>0)then
+       deallocate(emission_part(1)%cpuid)
+       deallocate(emission_part(1)%nparts)
+       deallocate(emission_part(1)%u)
+       deallocate(emission_part(1)%f8)
+       emission_part(1)%nactive=0
+       emission_part(1)%nparts_tot=0
+    end if
 #endif
 
     do icpu=1,ncpu

--- a/patch/mhd/merger/init_part.f90
+++ b/patch/mhd/merger/init_part.f90
@@ -733,7 +733,6 @@ contains
        deallocate(emission_part(1)%cpuid)
        deallocate(emission_part(1)%nparts)
        deallocate(emission_part(1)%u)
-       deallocate(emission_part(1)%f)
        deallocate(emission_part(1)%f8)
     end if
 
@@ -755,8 +754,8 @@ contains
     if(emission_part(1)%nactive>0)then
        allocate(emission_part(1)%cpuid(emission_part(1)%nactive))
        allocate(emission_part(1)%nparts(emission_part(1)%nactive))
-       allocate(emission_part(1)%u(emission_part(1)%nparts_tot*(twondim+1), 1:1))
-       allocate(emission_part(1)%f8(emission_part(1)%nparts_tot*2, 1:1))
+       allocate(emission_part(1)%u(1:twondim+1, 1:emission_part(1)%nparts_tot))
+       allocate(emission_part(1)%f8(1:2, 1:emission_part(1)%nparts_tot))
        idx=1
        do icpu=1,ncpu
          ncache=sendbuf(icpu)
@@ -776,16 +775,18 @@ contains
           call cmp_cpumap(xx_dp,cc,1)
           if(cc(1).ne.myid)then
              icpu=cc(1)
-             ibuf=sendbuf(icpu)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1),1)     = xp(ipart,1)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1) + 1,1) = xp(ipart,2)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1) + 2,1) = xp(ipart,3)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1) + 3,1) = vp(ipart,1)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1) + 4,1) = vp(ipart,2)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1) + 5,1) = vp(ipart,3)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1) + 6,1) = mp(ipart)
-             emission_part(1)%f8((sendbuf_cum(icpu)+ibuf)*2,1)              = part2int(typep(ipart))
-             emission_part(1)%f8((sendbuf_cum(icpu)+ibuf)*2 + 1,1)          = idp(ipart)
+             sendbuf(icpu)=sendbuf(icpu)+1
+             ! Index of the current particle inside the shared emission buffers
+             ibuf=sendbuf_cum(icpu)+sendbuf(icpu)
+             emission_part(1)%u(1,ibuf)=xp(ipart,1)
+             emission_part(1)%u(2,ibuf)=xp(ipart,2)
+             emission_part(1)%u(3,ibuf)=xp(ipart,3)
+             emission_part(1)%u(4,ibuf)=vp(ipart,1)
+             emission_part(1)%u(5,ibuf)=vp(ipart,2)
+             emission_part(1)%u(6,ibuf)=vp(ipart,3)
+             emission_part(1)%u(7,ibuf)=mp(ipart)
+             emission_part(1)%f8(1,ibuf)=part2int(typep(ipart))
+             emission_part(1)%f8(2,ibuf)=idp(ipart)
           else
              jpart=jpart+1
              xp(jpart,1:3)=xp(ipart,1:3)
@@ -857,8 +858,11 @@ contains
        ncache=recvbuf(icpu)
        if(ncache>0)then
 #ifdef LIGHT_MPI_COMM
-         allocate(reception(icpu,1)%pcomm%u(1:ncache,1:twondim+1))
-         allocate(reception(icpu,1)%pcomm%f8(1:ncache,1:2))
+         if(.not. associated(reception(icpu,1)%pcomm))then
+            allocate(reception(icpu,1)%pcomm)
+         end if
+         allocate(reception(icpu,1)%pcomm%u(1:twondim+1,1:ncache))
+         allocate(reception(icpu,1)%pcomm%f8(1:2,1:ncache))
 #else
          allocate(reception(icpu,1)%up(1:ncache,1:twondim+1))
          allocate(reception(icpu,1)%fp(1:ncache,1:2))
@@ -894,7 +898,7 @@ contains
           buf_count=ncache*(twondim+1)
           countsend=countsend+1
 #ifdef LIGHT_MPI_COMM
-          call MPI_ISEND(emission_part(1)%u(sendbuf_cum(icpu)+ncache,1),buf_count, &
+          call MPI_ISEND(emission_part(1)%u(1,sendbuf_cum(icpu)+1),buf_count, &
                & MPI_DOUBLE_PRECISION,icpu-1,&
                & tagu,MPI_COMM_WORLD,reqsend(countsend),info)
 #else
@@ -952,11 +956,11 @@ contains
           countsend=countsend+1
 #ifdef LIGHT_MPI_COMM
 #ifndef LONGINT
-          call MPI_ISEND(emission_part(1)%f8(sendbuf_cum(icpu)+ncache,1),buf_count, &
+          call MPI_ISEND(emission_part(1)%f8(1,sendbuf_cum(icpu)+1),buf_count, &
                 & MPI_INTEGER,icpu-1,&
                 & tagu,MPI_COMM_WORLD,reqsend(countsend),info)
 #else
-          call MPI_ISEND(emission_part(1)%f8(sendbuf_cum(icpu)+ncache),buf_count, &
+          call MPI_ISEND(emission_part(1)%f8(1,sendbuf_cum(icpu)+1),buf_count, &
                 & MPI_INTEGER8,icpu-1,&
                 & tagu,MPI_COMM_WORLD,reqsend(countsend),info)
 #endif
@@ -986,14 +990,14 @@ contains
        do ibuf=1,recvbuf(icpu)
           jpart=jpart+1
 #ifdef LIGHT_MPI_COMM
-          xp(jpart,1)=reception(icpu,1)%pcomm%u(ibuf,1)
-          xp(jpart,2)=reception(icpu,1)%pcomm%u(ibuf,2)
-          xp(jpart,3)=reception(icpu,1)%pcomm%u(ibuf,3)
-          vp(jpart,1)=reception(icpu,1)%pcomm%u(ibuf,4)
-          vp(jpart,2)=reception(icpu,1)%pcomm%u(ibuf,5)
-          vp(jpart,3)=reception(icpu,1)%pcomm%u(ibuf,6)
-          mp(jpart)  =reception(icpu,1)%pcomm%u(ibuf,7)
-          idp(jpart) =reception(icpu,1)%pcomm%f8(ibuf,2)
+          xp(jpart,1)=reception(icpu,1)%pcomm%u(1,ibuf)
+          xp(jpart,2)=reception(icpu,1)%pcomm%u(2,ibuf)
+          xp(jpart,3)=reception(icpu,1)%pcomm%u(3,ibuf)
+          vp(jpart,1)=reception(icpu,1)%pcomm%u(4,ibuf)
+          vp(jpart,2)=reception(icpu,1)%pcomm%u(5,ibuf)
+          vp(jpart,3)=reception(icpu,1)%pcomm%u(6,ibuf)
+          mp(jpart)  =reception(icpu,1)%pcomm%u(7,ibuf)
+          idp(jpart) =reception(icpu,1)%pcomm%f8(2,ibuf)
 #else
           xp(jpart,1)=reception(icpu,1)%up(ibuf,1)
           xp(jpart,2)=reception(icpu,1)%up(ibuf,2)
@@ -1023,8 +1027,14 @@ contains
 
     ! Deallocate communicators
 #ifdef LIGHT_MPI_COMM
-    deallocate(emission_part(1)%u)
-    deallocate(emission_part(1)%f8)
+    if(emission_part(1)%nactive>0)then
+       deallocate(emission_part(1)%cpuid)
+       deallocate(emission_part(1)%nparts)
+       deallocate(emission_part(1)%u)
+       deallocate(emission_part(1)%f8)
+       emission_part(1)%nactive=0
+       emission_part(1)%nparts_tot=0
+    end if
 #endif
     do icpu=1,ncpu
 #ifndef LIGHT_MPI_COMM

--- a/pm/init_part.f90
+++ b/pm/init_part.f90
@@ -741,7 +741,6 @@ contains
        deallocate(emission_part(1)%cpuid)
        deallocate(emission_part(1)%nparts)
        deallocate(emission_part(1)%u)
-       deallocate(emission_part(1)%f)
        deallocate(emission_part(1)%f8)
     end if
 

--- a/pm/init_part.f90
+++ b/pm/init_part.f90
@@ -762,8 +762,8 @@ contains
     if(emission_part(1)%nactive>0)then
        allocate(emission_part(1)%cpuid(emission_part(1)%nactive))
        allocate(emission_part(1)%nparts(emission_part(1)%nactive))
-       allocate(emission_part(1)%u(emission_part(1)%nparts_tot*(twondim+1), 1:1))
-       allocate(emission_part(1)%f8(emission_part(1)%nparts_tot*2, 1:1))
+       allocate(emission_part(1)%u(1:twondim+1, 1:emission_part(1)%nparts_tot))
+       allocate(emission_part(1)%f8(1:2, 1:emission_part(1)%nparts_tot))
        idx=1
        do icpu=1,ncpu
          ncache=sendbuf(icpu)
@@ -783,16 +783,18 @@ contains
           call cmp_cpumap(xx_dp,cc,1)
           if(cc(1).ne.myid)then
              icpu=cc(1)
-             ibuf=sendbuf(icpu)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1),1)     = xp(ipart,1)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1) + 1,1) = xp(ipart,2)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1) + 2,1) = xp(ipart,3)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1) + 3,1) = vp(ipart,1)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1) + 4,1) = vp(ipart,2)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1) + 5,1) = vp(ipart,3)
-             emission_part(1)%u((sendbuf_cum(icpu)+ibuf)*(twondim+1) + 6,1) = mp(ipart)
-             emission_part(1)%f8((sendbuf_cum(icpu)+ibuf)*2,1)              = part2int(typep(ipart))
-             emission_part(1)%f8((sendbuf_cum(icpu)+ibuf)*2 + 1,1)          = idp(ipart)
+             sendbuf(icpu)=sendbuf(icpu)+1
+             ! Index of the current particle inside the shared emission buffers
+             ibuf=sendbuf_cum(icpu)+sendbuf(icpu)
+             emission_part(1)%u(1,ibuf)=xp(ipart,1)
+             emission_part(1)%u(2,ibuf)=xp(ipart,2)
+             emission_part(1)%u(3,ibuf)=xp(ipart,3)
+             emission_part(1)%u(4,ibuf)=vp(ipart,1)
+             emission_part(1)%u(5,ibuf)=vp(ipart,2)
+             emission_part(1)%u(6,ibuf)=vp(ipart,3)
+             emission_part(1)%u(7,ibuf)=mp(ipart)
+             emission_part(1)%f8(1,ibuf)=part2int(typep(ipart))
+             emission_part(1)%f8(2,ibuf)=idp(ipart)
           else
              jpart=jpart+1
              xp(jpart,1:3)=xp(ipart,1:3)
@@ -864,8 +866,11 @@ contains
        ncache=recvbuf(icpu)
        if(ncache>0)then
 #ifdef LIGHT_MPI_COMM
-         allocate(reception(icpu,1)%pcomm%u(1:ncache,1:twondim+1))
-         allocate(reception(icpu,1)%pcomm%f8(1:ncache,1:2))
+         if(.not. associated(reception(icpu,1)%pcomm))then
+            allocate(reception(icpu,1)%pcomm)
+         end if
+         allocate(reception(icpu,1)%pcomm%u(1:twondim+1,1:ncache))
+         allocate(reception(icpu,1)%pcomm%f8(1:2,1:ncache))
 #else
          allocate(reception(icpu,1)%up(1:ncache,1:twondim+1))
          allocate(reception(icpu,1)%fp(1:ncache,1:2))
@@ -901,7 +906,7 @@ contains
           buf_count=ncache*(twondim+1)
           countsend=countsend+1
 #ifdef LIGHT_MPI_COMM
-          call MPI_ISEND(emission_part(1)%u(sendbuf_cum(icpu)+ncache,1),buf_count, &
+          call MPI_ISEND(emission_part(1)%u(1,sendbuf_cum(icpu)+1),buf_count, &
                & MPI_DOUBLE_PRECISION,icpu-1,&
                & tagu,MPI_COMM_WORLD,reqsend(countsend),info)
 #else
@@ -959,11 +964,11 @@ contains
           countsend=countsend+1
 #ifdef LIGHT_MPI_COMM
 #ifndef LONGINT
-          call MPI_ISEND(emission_part(1)%f8(sendbuf_cum(icpu)+ncache,1),buf_count, &
+          call MPI_ISEND(emission_part(1)%f8(1,sendbuf_cum(icpu)+1),buf_count, &
                 & MPI_INTEGER,icpu-1,&
                 & tagu,MPI_COMM_WORLD,reqsend(countsend),info)
 #else
-          call MPI_ISEND(emission_part(1)%f8(sendbuf_cum(icpu)+ncache,1),buf_count, &
+          call MPI_ISEND(emission_part(1)%f8(1,sendbuf_cum(icpu)+1),buf_count, &
                 & MPI_INTEGER8,icpu-1,&
                 & tagu,MPI_COMM_WORLD,reqsend(countsend),info)
 #endif
@@ -993,14 +998,14 @@ contains
        do ibuf=1,recvbuf(icpu)
           jpart=jpart+1
 #ifdef LIGHT_MPI_COMM
-          xp(jpart,1)=reception(icpu,1)%pcomm%u(ibuf,1)
-          xp(jpart,2)=reception(icpu,1)%pcomm%u(ibuf,2)
-          xp(jpart,3)=reception(icpu,1)%pcomm%u(ibuf,3)
-          vp(jpart,1)=reception(icpu,1)%pcomm%u(ibuf,4)
-          vp(jpart,2)=reception(icpu,1)%pcomm%u(ibuf,5)
-          vp(jpart,3)=reception(icpu,1)%pcomm%u(ibuf,6)
-          mp(jpart)  =reception(icpu,1)%pcomm%u(ibuf,7)
-          idp(jpart) =reception(icpu,1)%pcomm%f8(ibuf,2)
+          xp(jpart,1)=reception(icpu,1)%pcomm%u(1,ibuf)
+          xp(jpart,2)=reception(icpu,1)%pcomm%u(2,ibuf)
+          xp(jpart,3)=reception(icpu,1)%pcomm%u(3,ibuf)
+          vp(jpart,1)=reception(icpu,1)%pcomm%u(4,ibuf)
+          vp(jpart,2)=reception(icpu,1)%pcomm%u(5,ibuf)
+          vp(jpart,3)=reception(icpu,1)%pcomm%u(6,ibuf)
+          mp(jpart)  =reception(icpu,1)%pcomm%u(7,ibuf)
+          idp(jpart) =reception(icpu,1)%pcomm%f8(2,ibuf)
 #else
           xp(jpart,1)=reception(icpu,1)%up(ibuf,1)
           xp(jpart,2)=reception(icpu,1)%up(ibuf,2)
@@ -1030,8 +1035,14 @@ contains
 
     ! Deallocate communicators
 #ifdef LIGHT_MPI_COMM
-    deallocate(emission_part(1)%u)
-    deallocate(emission_part(1)%f8)
+    if(emission_part(1)%nactive>0)then
+       deallocate(emission_part(1)%cpuid)
+       deallocate(emission_part(1)%nparts)
+       deallocate(emission_part(1)%u)
+       deallocate(emission_part(1)%f8)
+       emission_part(1)%nactive=0
+       emission_part(1)%nparts_tot=0
+    end if
 #endif
 
     do icpu=1,ncpu


### PR DESCRIPTION
## Problem

Starting a cosmological run from grafic initial conditions crashes during initialisation when the code is compiled with `LIGHT_MPI_COMM=1`:

```
 Building initial AMR grid
 Reading file cosmo_128/ic_velcx
 Reading file cosmo_128/ic_velcy
 Reading file cosmo_128/ic_velcz
munmap_chunk(): invalid pointer
```

The `#ifdef LIGHT_MPI_COMM` branch of the particle redistribution in `init_part.f90` was never exercised and contained several independent bugs. The equivalent `#else` (regular MPI) branch is correct and is unchanged by this PR.

## Root cause

The per-CPU running counter was never advanced while filling the emission buffers — `sendbuf` was zeroed and then only read (`ibuf=sendbuf(icpu)`), unlike the regular MPI branch which increments it first. Two consequences:

1. **Heap corruption.** Combined with the 0-based flat indexing (`(sendbuf_cum(icpu)+ibuf)*(twondim+1)`, `... + 1`, …), the first CPU with particles to send wrote to `emission_part(1)%u(0,1)` and `%f8(0,1)`, i.e. 8 bytes before the start of the allocation, on top of the glibc malloc chunk header. This only surfaces when the block is freed, hence `munmap_chunk(): invalid pointer`.
2. **All off-domain particles silently dropped.** With `sendbuf` left at zero, the subsequent `MPI_ALLTOALL` exchanged zero counts, so nothing was sent or received.

## Additional bugs fixed in the same block

- **Wrong `MPI_ISEND` start addresses** — `%u(sendbuf_cum(icpu)+ncache,1)` and `%f8(sendbuf_cum(icpu)+ncache,1)`: the offsets were not scaled by the per-particle stride, and `+ncache` pointed past the start of the CPU's block.
- **Send and receive layouts disagreed.** The sender packed particle-major into the shared flat buffer while the receive buffer was `(1:ncache,1:twondim+1)`, which Fortran fills component-major.
- **`reception(icpu,1)%pcomm` dereferenced without being associated.** Every other site in the code guards this with `if(.not. associated(...)) allocate(...)`; this one did not.
- **`deallocate(emission_part(1)%f)`** — `%f` is never allocated for `emission_part` anywhere in the code.
- **`cpuid`/`nparts` leaked** on exit, so the next call to `virtual_tree_part` at level 1 would hit an allocate on an already-allocated array.
- **`patch/mhd/merger` only:** the `LONGINT` variant used `%f8(sendbuf_cum(icpu)+ncache)` — a single subscript on a rank-2 array, which cannot compile at all with `-DLONGINT -DLIGHT_MPI_COMM`.

## Approach

Beyond the minimal fixes, the emission buffers are now declared with their semantic shape, matching how `particle_tree.f90` handles the same structure:

```fortran
allocate(emission_part(1)%u(1:twondim+1, 1:emission_part(1)%nparts_tot))
allocate(emission_part(1)%f8(1:2, 1:emission_part(1)%nparts_tot))
```

This removes all the hand-rolled stride arithmetic, and the sends become the same "start of this CPU's particle block" idiom used elsewhere (`%u(1,sendbuf_cum(icpu)+1)`). The bytes on the wire are unchanged; the benefit is that a future off-by-one is an ordinary out-of-bounds subscript that `-fcheck=bounds` catches, rather than silent heap corruption.

Note that the property-major ordering is required by the light structure and cannot be aligned with the regular MPI ordering: `emission_part` is a single buffer shared by all destination CPUs, so each CPU's block must be contiguous for the sliced sends to work.

## Files changed

- `pm/init_part.f90`
- `patch/hydro/merger/init_part.f90`
- `patch/mhd/merger/init_part.f90` (verbatim copies of the same block)

## Testing

- `tests/poisson/cosmo` (grafic ICs, 128³, `levelmin=levelmax=7`) on 4 MPI ranks, `NDIM=3 MPI=1 LIGHT_MPI_COMM=1`: runs to completion, no heap errors.
- `part_00002.out*` and `clump_00002.txt*` are **bit-identical** to the same test built with `LIGHT_MPI_COMM=0`.
- Also builds clean with `-DLONGINT` combined with `LIGHT_MPI_COMM`.
- `patch/hydro/merger` builds and links clean.
- `patch/mhd/merger`: `init_part.f90` compiles clean (with and without `LONGINT`); the link still fails on `undefined reference to velana_ponomarenko_`. That routine does not exist anywhere in the tree and the identical failure reproduces on a pristine `dev` checkout, so it is pre-existing and out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
